### PR TITLE
Refactor a ton to make git statestore and cli work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 state.db
 .envrc
+skootcache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3764,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1bd37ce2324cf3bf85e5a25f96eb4baf0d5aa6eba43e7ae8958870c4ec48ed"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "indexmap 2.2.3",
  "itoa",
@@ -3969,6 +3969,7 @@ dependencies = [
  "skootrs-model",
  "skootrs-rest",
  "skootrs-statestore",
+ "strum",
  "tokio",
  "tracing",
  "tracing-bunyan-formatter",
@@ -3982,6 +3983,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.7",
  "askama",
+ "base64",
  "chrono",
  "futures",
  "octocrab 0.33.3",
@@ -3990,10 +3992,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "skootrs-model",
  "tempdir",
  "tokio",
  "tracing",
+ "url",
  "utoipa",
 ]
 
@@ -4007,6 +4011,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
+ "strum",
+ "url",
  "utoipa",
 ]
 
@@ -4036,6 +4043,7 @@ dependencies = [
 name = "skootrs-statestore"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "skootrs-lib",
  "skootrs-model",
  "surrealdb",
@@ -4200,6 +4208,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
+missing_docs = "warn"
 
 [workspace.lints.clippy]
 enum_glob_use = "deny"

--- a/skootrs-bin/Cargo.toml
+++ b/skootrs-bin/Cargo.toml
@@ -3,6 +3,10 @@ name = "skootrs-bin"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "skootrs"
+path = "src/main.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -27,6 +31,7 @@ reqwest = "0.11.24"
 base64 = "0.21.7"
 clio = { version = "0.3.5", features = ["clap", "clap-parse"] }
 serde = "1.0.197"
+strum = "0.26.1"
 
 [build-dependencies]
 clap_mangen = "0.2.20"

--- a/skootrs-bin/src/helpers.rs
+++ b/skootrs-bin/src/helpers.rs
@@ -6,20 +6,30 @@ use skootrs_lib::service::{
     facet::LocalFacetService,
     project::{LocalProjectService, ProjectService},
     repo::LocalRepoService,
-    source::{LocalSourceService, SourceService},
+    source::LocalSourceService,
 };
 use skootrs_model::{
     security_insights::insights10::SecurityInsightsVersion100YamlSchema,
     skootrs::{
-        EcosystemParams, GithubRepoParams, GithubUser, GoParams, InitializedProject, MavenParams,
-        ProjectParams, RepoParams, SkootError, SkootrsConfig, SourceParams, SUPPORTED_ECOSYSTEMS,
+        Config, EcosystemInitializeParams, FacetGetParams, FacetMapKey, GithubRepoParams,
+        GithubUser, GoParams, InitializedProject, MavenParams, ProjectCreateParams,
+        ProjectGetParams, ProjectOutputParams, ProjectOutputType, RepoCreateParams, SkootError,
+        SourceInitializeParams, SupportedEcosystems, SUPPORTED_ECOSYSTEMS,
     },
 };
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
+use strum::VariantNames;
+use tracing::debug;
 
-use skootrs_model::skootrs::facet::InitializedFacet;
 use skootrs_statestore::SurrealProjectStateStore;
+use skootrs_statestore::{
+    GitProjectStateStore, InMemoryProjectReferenceCache, ProjectReferenceCache, ProjectStateStore,
+};
 
+// TODO: This should have a project service member.
 pub struct Project;
 
 impl Project {
@@ -28,27 +38,35 @@ impl Project {
     /// Creates a new skootrs project by prompting the user for repository details and language selection.
     /// The project can be created for either Go or Maven ecosystems right now.
     /// The project is created in Github, cloned down, and then initialized along with any other security supporting
-    /// tasks. If the project_params is not provided, the user will be prompted for the project details.
+    /// tasks. If the `project_params` is not provided, the user will be prompted for the project details.
     ///
     /// # Errors
     ///
     /// Returns an error if the user is not authenticated with Github, or if the project can't be created
     /// for any other reason.
-    pub async fn create<T: ProjectService>(
-        config: &SkootrsConfig,
-        project_service: T,
-        project_params: Option<ProjectParams>,
+    pub async fn create<'a, T: ProjectService + ?Sized>(
+        config: &Config,
+        project_service: &'a T,
+        project_params: Option<ProjectCreateParams>,
     ) -> Result<(), SkootError> {
         let project_params = match project_params {
             Some(p) => p,
-            None => Project::prompt_project(config).await?,
+            None => Project::prompt_create(config).await?,
         };
 
-        project_service.initialize(project_params).await?;
+        let project = project_service.initialize(project_params).await?;
+        let git_state_store = GitProjectStateStore {
+            source: project.source.clone(),
+            source_service: LocalSourceService {},
+        };
+
+        let mut local_cache = InMemoryProjectReferenceCache::load_or_create("./skootcache")?;
+        git_state_store.create(project.clone()).await?;
+        local_cache.set(project.repo.full_url()).await?;
         Ok(())
     }
 
-    async fn prompt_project(config: &SkootrsConfig) -> Result<ProjectParams, SkootError> {
+    async fn prompt_create(config: &Config) -> Result<ProjectCreateParams, SkootError> {
         let name = Text::new("The name of the repository").prompt()?;
         let description = Text::new("The description of the repository").prompt()?;
         let user = octocrab::instance().current().user().await?.login;
@@ -66,39 +84,248 @@ impl Project {
                 .collect(),
         )
         .prompt()?;
-        let language = inquire::Select::new("Select a language", SUPPORTED_ECOSYSTEMS.to_vec());
+        let language =
+            inquire::Select::new("Select a language", SupportedEcosystems::VARIANTS.to_vec());
 
         let gh_org = match organization {
             x if x == user => GithubUser::User(x.to_string()),
             x => GithubUser::Organization(x.to_string()),
         };
 
-        let repo_params = match language.prompt()? {
-            "Go" => RepoParams::Github(GithubRepoParams {
-                name: name.clone(),
-                description,
-                organization: gh_org,
-            }),
-            "Maven" => RepoParams::Github(GithubRepoParams {
-                name: name.clone(),
-                description,
-                organization: gh_org,
-            }),
-            _ => {
-                unreachable!("Unsupported language")
-            }
-        };
-
-        Ok(ProjectParams {
-            name: name.clone(),
-            repo_params,
-            ecosystem_params: EcosystemParams::Go(GoParams {
+        let language_prompt = language.prompt()?;
+        let ecosystem_params = match SupportedEcosystems::from_str(language_prompt)? {
+            SupportedEcosystems::Go => EcosystemInitializeParams::Go(GoParams {
                 name: name.clone(),
                 host: format!("github.com/{organization}"),
             }),
-            source_params: SourceParams {
+            // TODO: Unclear if this is the right way to handle Maven group and artifact.
+            SupportedEcosystems::Maven => EcosystemInitializeParams::Maven(MavenParams {
+                group_id: format!("com.{organization}.{name}"),
+                artifact_id: name.clone(),
+            }),
+        };
+
+        let repo_params = RepoCreateParams::Github(GithubRepoParams {
+            name: name.clone(),
+            description,
+            organization: gh_org,
+        });
+
+        Ok(ProjectCreateParams {
+            name: name.clone(),
+            repo_params,
+            ecosystem_params,
+            source_params: SourceInitializeParams {
                 parent_path: config.local_project_path.clone(),
             },
+        })
+    }
+
+    /// Fetches and prints out the contents of an `InitializedProject` in JSON format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the project can't be fetched for some reason.
+    pub async fn get<'a, T: ProjectService + ?Sized>(
+        config: &Config,
+        _project_service: &'a T,
+        project_get_params: Option<ProjectGetParams>,
+    ) -> Result<InitializedProject, SkootError> {
+        let mut cache = InMemoryProjectReferenceCache::load_or_create("./skootcache")?;
+        let project_get_params = match project_get_params {
+            Some(p) => p,
+            None => Project::prompt_get(config).await?,
+        };
+        let project = cache.get(project_get_params.project_url.clone()).await?;
+        println!("{}", serde_json::to_string(&project)?);
+        Ok(project)
+    }
+
+    async fn prompt_get(_config: &Config) -> Result<ProjectGetParams, SkootError> {
+        let projects = Project::list().await?;
+        let selected_project =
+            inquire::Select::new("Select a project", projects.iter().collect()).prompt()?;
+        Ok(ProjectGetParams {
+            project_url: selected_project.clone(),
+        })
+    }
+
+    async fn list() -> Result<HashSet<String>, SkootError> {
+        let cache = InMemoryProjectReferenceCache::load_or_create("./skootcache")?;
+        let projects: HashSet<String> = cache.list().await?;
+        Ok(projects)
+    }
+
+    /// Prints out the list of projects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the list of Skootrs projects can't be fetched for some reason.
+    pub async fn print_list() -> Result<(), SkootError> {
+        let projects = Project::list().await?;
+        println!("{}", serde_json::to_string(&projects)?);
+        Ok(())
+    }
+}
+
+pub struct Facet;
+
+impl Facet {
+    /// Prints out the content of a facet. This includes things like source files or API bundles.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the facet content or project can't be fetched for some reason.
+    pub async fn get<'a, T: ProjectService + ?Sized>(
+        config: &Config,
+        project_service: &'a T,
+        facet_get_params: Option<FacetGetParams>,
+    ) -> Result<(), SkootError> {
+        let facet_get_params = if let Some(p) = facet_get_params {
+            p
+        } else {
+            let project = Project::get(config, project_service, None).await?;
+            let facet_map_keys = project.facet_key_set();
+            let fmk = Facet::prompt_get(config, facet_map_keys.into_iter().collect())?;
+            FacetGetParams {
+                project_url: project.repo.full_url(),
+                facet_map_key: fmk,
+            }
+        };
+
+        let facet_with_content = project_service
+            .get_facet_with_content(facet_get_params)
+            .await?;
+
+        debug!("{:?}", facet_with_content);
+        println!("{}", serde_json::to_string(&facet_with_content)?);
+
+        Ok(())
+    }
+
+    fn prompt_get(
+        _config: &Config,
+        facet_map_keys: Vec<FacetMapKey>,
+    ) -> Result<FacetMapKey, SkootError> {
+        let facet_type = inquire::Select::new("Select a facet", facet_map_keys).prompt()?;
+
+        Ok(facet_type)
+    }
+
+    /// Prints out the list of facets for a project. This includes things like source files or API bundles.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the project or list of facets can't be fetched for some reason.
+    pub async fn print_list<'a, T: ProjectService + ?Sized>(
+        config: &Config,
+        project_service: &'a T,
+        project_get_params: Option<ProjectGetParams>,
+    ) -> Result<(), SkootError> {
+        let project_get_params = match project_get_params {
+            Some(p) => p,
+            None => Project::prompt_get(config).await?,
+        };
+        let project = project_service.get(project_get_params).await?;
+        let facet_map_keys = project.facet_key_set();
+        println!("{}", serde_json::to_string(&facet_map_keys)?);
+        Ok(())
+    }
+}
+
+pub struct Output;
+
+impl Output {
+    /// Prints out the content of a project output. This includes things like SBOMs or SLSA attestations.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the project output can't be fetched from a project release.
+    pub async fn get<'a, T: ProjectService + ?Sized>(
+        config: &Config,
+        _project_service: &'a T,
+        project_output_params: Option<ProjectOutputParams>,
+    ) -> Result<(), SkootError> {
+        let project_output_params = match project_output_params {
+            Some(p) => p,
+            None => Output::prompt_project_output(config).await?,
+        };
+
+        let output = reqwest::get(project_output_params.project_output)
+            .await?
+            .text()
+            .await?;
+
+        println!("{output}");
+
+        Ok(())
+    }
+
+    async fn prompt_project_output(_config: &Config) -> Result<ProjectOutputParams, SkootError> {
+        let projects = Project::list().await?;
+        let selected_project =
+            inquire::Select::new("Select a project", projects.iter().collect()).prompt()?;
+        let selected_output_type =
+            inquire::Select::new("Select an output type", vec!["SBOM"]).prompt()?;
+        // TODO: This should probably be passed in by the config?
+        let mut cache = InMemoryProjectReferenceCache::load_or_create("./skootcache")?;
+        let project = cache.get(selected_project.clone()).await?;
+
+        let selected_output = match selected_output_type {
+            "SBOM" => {
+                let skootrs_model::skootrs::InitializedRepo::Github(repo) = &project.repo;
+                let sec_ins_content_items = octocrab::instance()
+                    .repos(repo.organization.get_name(), &repo.name)
+                    .get_content()
+                    .path("SECURITY-INSIGHTS.yml")
+                    .r#ref("main")
+                    .send()
+                    .await?;
+
+                let sec_ins = sec_ins_content_items
+                    .items
+                    .first()
+                    .ok_or_else(|| SkootError::from("Failed to get security insights"))?;
+
+                let content = sec_ins.content.as_ref().ok_or_else(|| {
+                    SkootError::from("Failed to get content of  security insights")
+                })?;
+                let content_decoded =
+                    base64::engine::general_purpose::STANDARD.decode(content.replace('\n', ""))?;
+                let content_str = std::str::from_utf8(&content_decoded)?;
+                let insights: SecurityInsightsVersion100YamlSchema =
+                    serde_yaml::from_str::<SecurityInsightsVersion100YamlSchema>(content_str)?;
+                let sbom_vec = insights
+                    .dependencies
+                    .ok_or_else(|| {
+                        SkootError::from("Failed to get dependencies value from security insights")
+                    })?
+                    .sbom
+                    .ok_or_else(|| {
+                        SkootError::from("Failed to get sbom value from security insights")
+                    })?;
+
+                let sbom_files: Vec<String> = sbom_vec
+                    .iter()
+                    .filter_map(|s| s.sbom_file.clone())
+                    .collect();
+
+                inquire::Select::new("Select an SBOM", sbom_files).prompt()?
+            }
+            _ => {
+                unimplemented!()
+            }
+        };
+
+        let selected_output_type_enum = match selected_output_type {
+            "SBOM" => ProjectOutputType::SBOM,
+            _ => ProjectOutputType::Custom("Other".to_string()),
+        };
+
+        Ok(ProjectOutputParams {
+            project_url: selected_project.clone(),
+            project_output_type: selected_output_type_enum,
+            project_output: selected_output.clone(),
         })
     }
 }
@@ -147,15 +374,15 @@ pub async fn create() -> std::result::Result<(), SkootError> {
                 name: name.clone(),
                 host: format!("github.com/{organization}"),
             };
-            let project_params = ProjectParams {
+            let project_params = ProjectCreateParams {
                 name: name.clone(),
-                repo_params: RepoParams::Github(GithubRepoParams {
+                repo_params: RepoCreateParams::Github(GithubRepoParams {
                     name,
                     description,
                     organization: gh_org,
                 }),
-                ecosystem_params: EcosystemParams::Go(go_params),
-                source_params: SourceParams {
+                ecosystem_params: EcosystemInitializeParams::Go(go_params),
+                source_params: SourceInitializeParams {
                     parent_path: "/tmp".to_string(), // FIXME: This should be configurable
                 },
             };
@@ -175,15 +402,15 @@ pub async fn create() -> std::result::Result<(), SkootError> {
                 artifact_id: name.clone(),
             };
 
-            let project_params = ProjectParams {
+            let project_params = ProjectCreateParams {
                 name: name.clone(),
-                repo_params: RepoParams::Github(GithubRepoParams {
+                repo_params: RepoCreateParams::Github(GithubRepoParams {
                     name,
                     description,
                     organization: gh_org,
                 }),
-                ecosystem_params: EcosystemParams::Maven(maven_params),
-                source_params: SourceParams {
+                ecosystem_params: EcosystemInitializeParams::Maven(maven_params),
+                source_params: SourceInitializeParams {
                     parent_path: "/tmp".to_string(), // FIXME: This should be configurable
                 },
             };
@@ -217,7 +444,7 @@ pub async fn create() -> std::result::Result<(), SkootError> {
 ///
 /// Returns an error if the state store is not able to be accessed or if the selected project or facet
 /// is not found.
-pub async fn get_facet() -> std::result::Result<(), SkootError> {
+/*pub async fn get_facet() -> std::result::Result<(), SkootError> {
     let project = prompt_project().await?;
 
     let facet_to_project: HashMap<String, InitializedFacet> = project
@@ -254,7 +481,7 @@ pub async fn get_facet() -> std::result::Result<(), SkootError> {
     println!("{facet_content}");
 
     Ok(())
-}
+}*/
 
 /// Returns `Ok(())` if the able to print out a dump of the statestore.
 ///
@@ -273,7 +500,7 @@ async fn get_all() -> std::result::Result<Vec<InitializedProject>, SkootError> {
     let projects = state_store.select_all().await?;
     Ok(projects)
 }
-
+/*
 fn get_facet_content(
     facet: &InitializedFacet,
     project: &InitializedProject,
@@ -299,7 +526,7 @@ fn get_facet_content(
             Ok(content.join("\n"))
         }
     }
-}
+}*/
 
 /// This function is for prompting the user to get outputs from a Skootrs project
 ///

--- a/skootrs-lib/Cargo.toml
+++ b/skootrs-lib/Cargo.toml
@@ -19,6 +19,9 @@ tracing = "0.1"
 futures = "0.3.30"
 skootrs-model = { path = "../skootrs-model" }
 ahash = "0.8.7"
+sha2 = "0.10.8"
+url = "2.5.0"
+base64 = "0.21.7"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/skootrs-lib/src/service/ecosystem.rs
+++ b/skootrs-lib/src/service/ecosystem.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use tracing::info;
 
 use skootrs_model::skootrs::{
-    EcosystemParams, GoParams, InitializedEcosystem, InitializedGo, InitializedMaven,
+    EcosystemInitializeParams, GoParams, InitializedEcosystem, InitializedGo, InitializedMaven,
     InitializedSource, MavenParams, SkootError,
 };
 
@@ -20,7 +20,7 @@ pub trait EcosystemService {
     /// Returns an error if the ecosystem can't be initialized.
     fn initialize(
         &self,
-        params: EcosystemParams,
+        params: EcosystemInitializeParams,
         source: InitializedSource,
     ) -> Result<InitializedEcosystem, SkootError>;
 }
@@ -33,18 +33,18 @@ pub struct LocalEcosystemService {}
 impl EcosystemService for LocalEcosystemService {
     fn initialize(
         &self,
-        params: EcosystemParams,
+        params: EcosystemInitializeParams,
         source: InitializedSource,
     ) -> Result<InitializedEcosystem, SkootError> {
         match params {
-            EcosystemParams::Maven(m) => {
+            EcosystemInitializeParams::Maven(m) => {
                 LocalMavenEcosystemHandler::initialize(&source.path, &m)?;
                 Ok(InitializedEcosystem::Maven(InitializedMaven {
                     group_id: m.group_id,
                     artifact_id: m.artifact_id,
                 }))
             }
-            EcosystemParams::Go(g) => {
+            EcosystemInitializeParams::Go(g) => {
                 LocalGoEcosystemHandler::initialize(&source.path, &g)?;
                 Ok(InitializedEcosystem::Go(InitializedGo {
                     name: g.name,

--- a/skootrs-lib/src/service/project.rs
+++ b/skootrs-lib/src/service/project.rs
@@ -15,37 +15,61 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use std::error::Error;
+use std::collections::HashMap;
 
 use crate::service::facet::{FacetSetParamsGenerator, RootFacetService};
+
 use skootrs_model::skootrs::{
-    facet::CommonFacetParams, InitializedProject, InitializedSource, ProjectParams,
+    facet::{CommonFacetCreateParams, InitializedFacet, SourceFile},
+    FacetGetParams, FacetMapKey, InitializedProject, InitializedSource, ProjectCreateParams,
+    ProjectGetParams, SkootError,
 };
 
-use super::{
-    ecosystem::EcosystemService,
-    repo::RepoService,
-    source::SourceService,
-};
-use tracing::debug;
+use super::{ecosystem::EcosystemService, repo::RepoService, source::SourceService};
+use tracing::{debug, error, info};
 
 /// The `ProjectService` trait provides an interface for initializing and managing a Skootrs project.
 pub trait ProjectService {
     /// Initializes a Skootrs project.
-    ///h
+    ///
     /// # Errors
     ///
     /// Returns an error if the project can't be initialized for any reason.
     fn initialize(
         &self,
-        params: ProjectParams,
-    ) -> impl std::future::Future<Output = Result<InitializedProject, Box<dyn Error + Send + Sync>>> + Send;
+        params: ProjectCreateParams,
+    ) -> impl std::future::Future<Output = Result<InitializedProject, SkootError>> + Send;
+
+    /// Gets an initialized project.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the project can't be found or fetched.
+    fn get(
+        &self,
+        params: ProjectGetParams,
+    ) -> impl std::future::Future<Output = Result<InitializedProject, SkootError>> + Send;
+
+    /// Gets a facet along with its content from an initialized project.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the facet can't be found or fetched.
+    fn get_facet_with_content(
+        &self,
+        params: FacetGetParams,
+    ) -> impl std::future::Future<Output = Result<InitializedFacet, SkootError>> + Send;
 }
 
 /// The `LocalProjectService` struct provides an implementation of the `ProjectService` trait for initializing
 /// and managing a Skootrs project on the local machine.
 #[derive(Debug)]
-pub struct LocalProjectService<RS: RepoService, ES: EcosystemService, SS: SourceService, FS: RootFacetService> {
+pub struct LocalProjectService<
+    RS: RepoService,
+    ES: EcosystemService,
+    SS: SourceService,
+    FS: RootFacetService,
+> {
     pub repo_service: RS,
     pub ecosystem_service: ES,
     pub source_service: SS,
@@ -61,8 +85,8 @@ where
 {
     async fn initialize(
         &self,
-        params: ProjectParams,
-    ) -> Result<InitializedProject, Box<dyn Error + Send + Sync>> {
+        params: ProjectCreateParams,
+    ) -> Result<InitializedProject, SkootError> {
         debug!("Starting repo initialization");
         let initialized_repo = self
             .repo_service
@@ -79,15 +103,15 @@ where
         debug!("Starting facet initialization");
         // TODO: This is ugly and this should probably be configured somewhere better, preferably outside of code.
         let facet_set_params_generator = FacetSetParamsGenerator {};
-        let common_params = CommonFacetParams {
+        let common_params = CommonFacetCreateParams {
             project_name: params.name.clone(),
             source: initialized_source.clone(),
             repo: initialized_repo.clone(),
             ecosystem: initialized_ecosystem.clone(),
         };
         //let facet_set_params = facet_set_params_generator.generate_default(&common_params)?;
-        let source_facet_set_params =
-            facet_set_params_generator.generate_default_source_bundle_facet_params(&common_params)?;
+        let source_facet_set_params = facet_set_params_generator
+            .generate_default_source_bundle_facet_params(&common_params)?;
         let api_facet_set_params =
             facet_set_params_generator.generate_default_api_bundle(&common_params)?;
         let initialized_source_facets = self
@@ -103,9 +127,14 @@ where
             .facet_service
             .initialize_all(api_facet_set_params)
             .await?;
-        let initialized_facets = [initialized_source_facets, initialized_api_facets].concat();
+        // FIXME: Also add facet by name as well
+        let initialized_facets = [initialized_source_facets, initialized_api_facets]
+            .concat()
+            .into_iter()
+            .map(|f| (FacetMapKey::Type(f.facet_type()), f))
+            .collect::<HashMap<FacetMapKey, InitializedFacet>>();
 
-        debug!("Completed project initialization");
+        info!("Completed project initialization");
 
         Ok(InitializedProject {
             repo: initialized_repo,
@@ -114,15 +143,97 @@ where
             facets: initialized_facets,
         })
     }
+
+    async fn get(&self, params: ProjectGetParams) -> Result<InitializedProject, SkootError> {
+        let get_repo_params = skootrs_model::skootrs::InitializedRepoGetParams {
+            repo_url: params.project_url.clone(),
+        };
+        debug!("Getting repo: {get_repo_params:?}");
+        let repo = self.repo_service.get(get_repo_params).await?;
+        // TODO: Skootrs file path should be kept as a global constant somewhere.
+        let skootrs_file = self
+            .repo_service
+            .fetch_file_content(&repo, ".skootrs")
+            .await?;
+        debug!("Skootrs file: {skootrs_file}");
+        let initialized_project: InitializedProject = serde_json::from_str(&skootrs_file)?;
+        Ok(initialized_project)
+    }
+
+    async fn get_facet_with_content(
+        &self,
+        params: FacetGetParams,
+    ) -> Result<InitializedFacet, SkootError> {
+        let initialized_project = self
+            .get(ProjectGetParams {
+                project_url: params.project_url.clone(),
+            })
+            .await?;
+        //let facet = initialized_project.facets.iter().find(|f| f.facet_type() == params.facet_type);
+        let facet = initialized_project
+            .facets
+            .get(&params.facet_map_key)
+            .ok_or(SkootError::from("Facet not found"))?;
+
+        match facet {
+            InitializedFacet::SourceBundle(s) => {
+                if let Some(source_files) = s.source_files.clone() {
+                    let source_files_content_futures = source_files.into_iter().map(|sf| async {
+                        let path = std::path::Path::new(&sf.path).join(&sf.name);
+                        // FIXME: This stripped path should probably be handled by the fetch facet content function
+                        let stripped_path = path.strip_prefix("./").unwrap_or(&path);
+
+                        let content = self
+                            .repo_service
+                            .fetch_file_content(&initialized_project.repo, stripped_path)
+                            .await;
+                        match content {
+                            Ok(c) => Ok((sf, c)),
+                            Err(e) => {
+                                error!(
+                                    "Error fetching file content for path: {stripped_path:#?}, error: {e}"
+                                );
+                                Err(e)
+                            }
+                        }
+                    });
+                    let source_files_content_results =
+                        futures::future::join_all(source_files_content_futures)
+                            .await
+                            .into_iter()
+                            .collect::<Result<Vec<(SourceFile, String)>, SkootError>>()?;
+                    let source_files_content_map = source_files_content_results
+                        .into_iter()
+                        .collect::<HashMap<SourceFile, String>>();
+                    Ok(InitializedFacet::SourceBundle(
+                        skootrs_model::skootrs::facet::SourceBundleFacet {
+                            facet_type: skootrs_model::skootrs::facet::SupportedFacetType::Readme,
+                            source_files: None,
+                            source_files_content: Some(source_files_content_map),
+                        },
+                    ))
+                } else {
+                    Err(SkootError::from("No source files found"))
+                }
+            }
+            InitializedFacet::APIBundle(a) => Ok(InitializedFacet::APIBundle(a.clone())),
+            InitializedFacet::SourceFile(_) => Err(SkootError::from("Facet type not supported")),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use skootrs_model::skootrs::{
         facet::{
-            APIBundleFacet, APIContent, FacetParams, FacetSetParams, InitializedFacet,
-            SourceBundleFacet, SourceFileContent, SupportedFacetType,
-        }, EcosystemParams, GithubRepoParams, GithubUser, GoParams, InitializedEcosystem, InitializedGithubRepo, InitializedGo, InitializedMaven, InitializedRepo, RepoParams, SkootError, SourceParams
+            APIBundleFacet, APIContent, FacetCreateParams, FacetSetCreateParams, SourceBundleFacet,
+            SupportedFacetType,
+        },
+        EcosystemInitializeParams, GithubRepoParams, GithubUser, GoParams, InitializedEcosystem,
+        InitializedGithubRepo, InitializedGo, InitializedMaven, InitializedRepo, RepoCreateParams,
+        SourceInitializeParams,
     };
 
     use super::*;
@@ -132,24 +243,23 @@ mod tests {
     struct MockFacetService;
 
     impl RepoService for MockRepoService {
-        fn initialize(&self, params: RepoParams) -> impl std::future::Future<Output = Result<InitializedRepo, SkootError>> + Send {
-            async {
-                let inner_params = match params {
-                    RepoParams::Github(g) => g,
-                };
-    
-                // Special case for testing error handling
-                if inner_params.name == "error" {
-                    return Err("Error".into())
-                }
-    
-                let initialized_repo = InitializedRepo::Github(InitializedGithubRepo {
-                    name: inner_params.name,
-                    organization: inner_params.organization,
-                });
-    
-                Ok(initialized_repo)
+        async fn initialize(
+            &self,
+            params: RepoCreateParams,
+        ) -> Result<InitializedRepo, SkootError> {
+            let RepoCreateParams::Github(inner_params) = params;
+
+            // Special case for testing error handling
+            if inner_params.name == "error" {
+                return Err("Error".into());
             }
+
+            let initialized_repo = InitializedRepo::Github(InitializedGithubRepo {
+                name: inner_params.name,
+                organization: inner_params.organization,
+            });
+
+            Ok(initialized_repo)
         }
 
         fn clone_local(
@@ -157,9 +267,7 @@ mod tests {
             initialized_repo: InitializedRepo,
             path: String,
         ) -> Result<InitializedSource, SkootError> {
-            let inner_repo = match initialized_repo {
-                InitializedRepo::Github(g) => g,
-            };
+            let InitializedRepo::Github(inner_repo) = initialized_repo;
 
             if inner_repo.name == "error" {
                 return Err("Error".into());
@@ -171,29 +279,66 @@ mod tests {
 
             Ok(initialized_source)
         }
+
+        fn clone_local_or_pull(
+            &self,
+            initialized_repo: InitializedRepo,
+            path: String,
+        ) -> Result<InitializedSource, SkootError> {
+            self.clone_local(initialized_repo, path)
+        }
+
+        async fn get(
+            &self,
+            params: skootrs_model::skootrs::InitializedRepoGetParams,
+        ) -> Result<InitializedRepo, SkootError> {
+            let repo_url = params.repo_url.clone();
+            if repo_url == "error" {
+                return Err("Error".into());
+            }
+
+            let initialized_repo = InitializedRepo::Github(InitializedGithubRepo {
+                name: "test".to_string(),
+                organization: GithubUser::User("testuser".to_string()),
+            });
+
+            Ok(initialized_repo)
+        }
+
+        async fn fetch_file_content<P: AsRef<std::path::Path> + Send>(
+            &self,
+            _initialized_repo: &InitializedRepo,
+            path: P,
+        ) -> Result<String, SkootError> {
+            if path.as_ref().to_str().unwrap() == "error" {
+                return Err("Error".into());
+            }
+
+            Ok("Worked".to_string())
+        }
     }
 
     impl EcosystemService for MockEcosystemService {
         fn initialize(
             &self,
-            params: EcosystemParams,
+            params: EcosystemInitializeParams,
             _source: InitializedSource,
         ) -> Result<InitializedEcosystem, SkootError> {
             let initialized_ecosystem = match params {
-                EcosystemParams::Go(g) => {
+                EcosystemInitializeParams::Go(g) => {
                     if g.host == "error" {
                         return Err("Error".into());
                     }
-                    InitializedEcosystem::Go(InitializedGo{
+                    InitializedEcosystem::Go(InitializedGo {
                         name: g.name,
                         host: g.host,
                     })
                 }
-                EcosystemParams::Maven(m) => {
+                EcosystemInitializeParams::Maven(m) => {
                     if m.group_id == "error" {
                         return Err("Error".into());
                     }
-                    InitializedEcosystem::Maven(InitializedMaven{
+                    InitializedEcosystem::Maven(InitializedMaven {
                         group_id: m.group_id,
                         artifact_id: m.artifact_id,
                     })
@@ -207,7 +352,7 @@ mod tests {
     impl SourceService for MockSourceService {
         fn initialize(
             &self,
-            params: skootrs_model::skootrs::SourceParams,
+            params: skootrs_model::skootrs::SourceInitializeParams,
             initialized_repo: InitializedRepo,
         ) -> Result<InitializedSource, SkootError> {
             if params.parent_path == "error" {
@@ -227,7 +372,7 @@ mod tests {
 
         fn commit_and_push_changes(
             &self,
-            source: InitializedSource,
+            _source: InitializedSource,
             message: String,
         ) -> Result<(), SkootError> {
             if message == "error" {
@@ -263,84 +408,100 @@ mod tests {
 
             Ok("Worked".to_string())
         }
+
+        fn hash_file<P: AsRef<Path>>(
+            &self,
+            _source: &InitializedSource,
+            path: P,
+            _name: String,
+        ) -> Result<String, SkootError> {
+            if path.as_ref().to_str().unwrap() == "error" {
+                return Err("Error".into());
+            }
+
+            Ok("fakehash".to_string())
+        }
+
+        fn pull_updates(&self, source: InitializedSource) -> Result<(), SkootError> {
+            if source.path == "error" {
+                return Err("Error".into());
+            }
+
+            Ok(())
+        }
     }
 
     impl RootFacetService for MockFacetService {
-        fn initialize(
+        async fn initialize(
             &self,
-            params: FacetParams,
-        ) -> impl std::future::Future<Output = Result<InitializedFacet, SkootError>> + Send
-        {
-            async {
-                match params {
-                    FacetParams::SourceFile(_) => Err("Error".into()),
-                    FacetParams::SourceBundle(s) => {
-                        if s.common.project_name == "error" {
-                            return Err("Error".into());
-                        }
-                        let source_bundle_facet = SourceBundleFacet {
-                            source_files: vec![SourceFileContent {
-                                name: "README.md".to_string(),
-                                path: "./".to_string(),
-                                content: s.common.project_name.clone(),
-                            }],
-                            facet_type: SupportedFacetType::Readme,
-                        };
-
-                        Ok(InitializedFacet::SourceBundle(source_bundle_facet))
+            params: FacetCreateParams,
+        ) -> Result<InitializedFacet, SkootError> {
+            match params {
+                FacetCreateParams::SourceFile(_) => Err("Error".into()),
+                FacetCreateParams::SourceBundle(s) => {
+                    if s.common.project_name == "error" {
+                        return Err("Error".into());
                     }
-                    FacetParams::APIBundle(a) => {
-                        if a.common.project_name == "error" {
-                            return Err("Error".into());
-                        }
-                        let api_bundle_facet = APIBundleFacet {
-                            apis: vec![APIContent {
-                                name: "test".to_string(),
-                                url: "https://foo.bar/test".to_string(),
-                                response: "worked".to_string(),
-                            }],
-                            facet_type: SupportedFacetType::BranchProtection,
-                        };
+                    let source_bundle_facet = SourceBundleFacet {
+                        source_files: Some(vec![SourceFile {
+                            name: "README.md".to_string(),
+                            path: "./".to_string(),
+                            hash: "fakehash".to_string(),
+                        }]),
+                        facet_type: SupportedFacetType::Readme,
+                        source_files_content: None,
+                    };
 
-                        Ok(InitializedFacet::APIBundle(api_bundle_facet))
+                    Ok(InitializedFacet::SourceBundle(source_bundle_facet))
+                }
+                FacetCreateParams::APIBundle(a) => {
+                    if a.common.project_name == "error" {
+                        return Err("Error".into());
                     }
+                    let api_bundle_facet = APIBundleFacet {
+                        apis: vec![APIContent {
+                            name: "test".to_string(),
+                            url: "https://foo.bar/test".to_string(),
+                            response: "worked".to_string(),
+                        }],
+                        facet_type: SupportedFacetType::BranchProtection,
+                    };
+
+                    Ok(InitializedFacet::APIBundle(api_bundle_facet))
                 }
             }
         }
 
-        fn initialize_all(
+        async fn initialize_all(
             &self,
-            params: FacetSetParams,
-        ) -> impl std::future::Future<Output = Result<Vec<InitializedFacet>, SkootError>> + Send
-        {
-            async {
-                let mut initialized_facets = Vec::new();
-                for facet_params in params.facets_params {
-                    let initialized_facet = self.initialize(facet_params).await?;
-                    initialized_facets.push(initialized_facet);
-                }
-
-                Ok(initialized_facets)
+            params: FacetSetCreateParams,
+        ) -> Result<Vec<InitializedFacet>, SkootError> {
+            let mut initialized_facets = Vec::new();
+            for facet_params in params.facets_params {
+                let initialized_facet = self.initialize(facet_params).await?;
+                initialized_facets.push(initialized_facet);
             }
+
+            Ok(initialized_facets)
         }
     }
 
     #[tokio::test]
     async fn test_initialize_project() {
-        let project_params = ProjectParams { 
-            name: "test".to_string(), 
-            repo_params: RepoParams::Github(GithubRepoParams { 
+        let project_params = ProjectCreateParams {
+            name: "test".to_string(),
+            repo_params: RepoCreateParams::Github(GithubRepoParams {
                 name: "test".to_string(),
-                description: "foobar".to_string(), 
-                organization: GithubUser::User("testuser".to_string())
-            }), 
-            ecosystem_params: EcosystemParams::Go(GoParams { 
-                name: "test".to_string(), 
-                host: "github.com".to_string() 
+                description: "foobar".to_string(),
+                organization: GithubUser::User("testuser".to_string()),
             }),
-            source_params: SourceParams { 
-                parent_path: "test".to_string() 
-            }
+            ecosystem_params: EcosystemInitializeParams::Go(GoParams {
+                name: "test".to_string(),
+                host: "github.com".to_string(),
+            }),
+            source_params: SourceInitializeParams {
+                parent_path: "test".to_string(),
+            },
         };
 
         let local_project_service = LocalProjectService {
@@ -362,8 +523,11 @@ mod tests {
         };
         assert!(module.name == "test");
         assert!(initialized_project.source.path == "test/test");
-        // TODO: This just pulls in the default set of facets which has a length of 12.
-        // This should be more configurable.
-        assert_eq!(initialized_project.facets.len(), 12);
+        println!("{:#?}", initialized_project.facets);
+
+        // TODO: This will always be equal to 2 because we are initializing two facets in the mock facet service
+        // and the `HashMap` for the facets will keep getting the same key. This is probably not a great way
+        // of handling that.
+        assert_eq!(initialized_project.facets.len(), 2);
     }
 }

--- a/skootrs-model/Cargo.toml
+++ b/skootrs-model/Cargo.toml
@@ -13,6 +13,9 @@ utoipa = { version = "4.1.0" }
 chrono = { version = "0.4.31", features = ["serde"] }
 schemars = { version = "0.8.16", features = ["chrono", "url"] }
 regress = "0.7.1"
+sha2 = "0.10.8"
+url = "2.5.0"
+strum = { version = "0.26.1", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/skootrs-model/src/cd_events/repo_created.rs
+++ b/skootrs-model/src/cd_events/repo_created.rs
@@ -23,6 +23,7 @@
 #![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::to_string_trait_impl)]
+#![allow(missing_docs)]
 
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -51,7 +52,8 @@ impl From<&Self> for RepositoryCreatedEvent {
     }
 }
 impl RepositoryCreatedEvent {
-    #[must_use] pub fn builder() -> builder::RepositoryCreatedEvent {
+    #[must_use]
+    pub fn builder() -> builder::RepositoryCreatedEvent {
         builder::RepositoryCreatedEvent::default()
     }
 }
@@ -71,7 +73,8 @@ impl From<&Self> for RepositoryCreatedEventContext {
     }
 }
 impl RepositoryCreatedEventContext {
-    #[must_use] pub fn builder() -> builder::RepositoryCreatedEventContext {
+    #[must_use]
+    pub fn builder() -> builder::RepositoryCreatedEventContext {
         builder::RepositoryCreatedEventContext::default()
     }
 }
@@ -270,7 +273,8 @@ impl From<&Self> for RepositoryCreatedEventSubject {
     }
 }
 impl RepositoryCreatedEventSubject {
-    #[must_use] pub fn builder() -> builder::RepositoryCreatedEventSubject {
+    #[must_use]
+    pub fn builder() -> builder::RepositoryCreatedEventSubject {
         builder::RepositoryCreatedEventSubject::default()
     }
 }
@@ -290,7 +294,8 @@ impl From<&Self> for RepositoryCreatedEventSubjectContent {
     }
 }
 impl RepositoryCreatedEventSubjectContent {
-    #[must_use] pub fn builder() -> builder::RepositoryCreatedEventSubjectContent {
+    #[must_use]
+    pub fn builder() -> builder::RepositoryCreatedEventSubjectContent {
         builder::RepositoryCreatedEventSubjectContent::default()
     }
 }
@@ -553,9 +558,7 @@ pub mod builder {
             T::Error: std::fmt::Display,
         {
             self.custom_data_content_type = value.try_into().map_err(|e| {
-                format!(
-                    "error converting supplied value for custom_data_content_type: {e}"
-                )
+                format!("error converting supplied value for custom_data_content_type: {e}")
             });
             self
         }

--- a/skootrs-model/src/lib.rs
+++ b/skootrs-model/src/lib.rs
@@ -15,15 +15,18 @@
 
 //! This is where all the models for the Skootrs project are defined. The models are just the data
 //! representing the abstractions around a project like its repository, source code, and facets.
-//! 
+//!
 //! The models here need to be (de)serializable, i.e. implementing `serde::Serialize` and `serde::Deserialize`
 //! so that they can be easily used in RPC calls and other places where data needs to be sent over the wire.
 //! For example the REST API that is in the `skootrs-rest` crate. Currently for the sake of simplicity we don'T
 //! use much in the way of generics and trait objects because of issues with (de)serialization.
-//! 
+//!
 //! All the models besides those that fall under `/skootrs` are considered external. In most cases they are
 //! code generated. The models in `/skootrs` are the core models for the Skootrs project and defined for the
 //! purpose of the project.
-pub mod security_insights;
+/// CD Events models.
 pub mod cd_events;
+/// Security Insights models.
+pub mod security_insights;
+/// Skootrs specific models.
 pub mod skootrs;

--- a/skootrs-model/src/security_insights/insights10.rs
+++ b/skootrs-model/src/security_insights/insights10.rs
@@ -21,6 +21,8 @@
 #![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::unwrap_used)]
+#![allow(missing_docs)]
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 ///YAML schema for security-insights.yml
@@ -43,32 +45,33 @@ pub struct SecurityInsightsVersion100YamlSchema {
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub security_artifacts: Option<
-        SecurityInsightsVersion100YamlSchemaSecurityArtifacts,
-    >,
+    pub security_artifacts: Option<SecurityInsightsVersion100YamlSchemaSecurityArtifacts>,
     #[serde(
         rename = "security-assessments",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub security_assessments: Option<
-        Vec<SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem>,
-    >,
+    pub security_assessments:
+        Option<Vec<SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem>>,
     #[serde(rename = "security-contacts")]
     pub security_contacts: Vec<SecurityInsightsVersion100YamlSchemaSecurityContactsItem>,
-    #[serde(rename = "security-testing", default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        rename = "security-testing",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub security_testing: Vec<SecurityInsightsVersion100YamlSchemaSecurityTestingItem>,
     #[serde(rename = "vulnerability-reporting")]
     pub vulnerability_reporting: SecurityInsightsVersion100YamlSchemaVulnerabilityReporting,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchema {
+impl From<&Self> for SecurityInsightsVersion100YamlSchema {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchema {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchema {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchema {
         builder::SecurityInsightsVersion100YamlSchema::default()
     }
 }
@@ -87,9 +90,8 @@ pub struct SecurityInsightsVersion100YamlSchemaContributionPolicy {
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub automated_tools_list: Option<
-        Vec<SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem>,
-    >,
+    pub automated_tools_list:
+        Option<Vec<SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem>>,
     ///Link to the project code of conduct.
     #[serde(
         rename = "code-of-conduct",
@@ -105,14 +107,14 @@ pub struct SecurityInsightsVersion100YamlSchemaContributionPolicy {
     )]
     pub contributing_policy: Option<String>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaContributionPolicy {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaContributionPolicy {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaContributionPolicy {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaContributionPolicy {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaContributionPolicy {
         builder::SecurityInsightsVersion100YamlSchemaContributionPolicy::default()
     }
 }
@@ -126,23 +128,21 @@ pub struct SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsL
     pub automated_tool: String,
     ///Short comment.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub comment: Option<
-        SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment,
-    >,
+    pub comment:
+        Option<SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment>,
     ///Define sub-paths where the automated actions are allowed or denied.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<Vec<String>>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
+    #[must_use]
+    pub fn builder(
+    ) -> builder::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
         builder::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem::default()
     }
 }
@@ -158,7 +158,7 @@ impl SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListIte
     PartialEq,
     PartialOrd,
     Serialize,
-    schemars::JsonSchema
+    schemars::JsonSchema,
 )]
 pub enum SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction {
     #[serde(rename = "allowed")]
@@ -166,18 +166,16 @@ pub enum SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsLis
     #[serde(rename = "denied")]
     Denied,
 }
-impl From<
-    &Self,
->
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self>
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction
+{
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl ToString
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction
+{
     fn to_string(&self) -> String {
         match *self {
             Self::Allowed => "allowed".to_string(),
@@ -186,7 +184,8 @@ for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem
     }
 }
 impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction
+{
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -197,21 +196,24 @@ for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemAction
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -219,88 +221,84 @@ for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem
 }
 ///Short comment.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment(
     String,
 );
 impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment
+{
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<
-    SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment,
-> for String {
+impl From<SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment>
+    for String
+{
     fn from(
         value: SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment,
     ) -> Self {
         value.0
     }
 }
-impl From<
-    &Self,
->
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self>
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment
+{
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment
+{
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment {
+    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -311,9 +309,8 @@ pub struct SecurityInsightsVersion100YamlSchemaDependencies {
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub dependencies_lifecycle: Option<
-        SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle,
-    >,
+    pub dependencies_lifecycle:
+        Option<SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle>,
     #[serde(
         rename = "dependencies-lists",
         default,
@@ -325,9 +322,8 @@ pub struct SecurityInsightsVersion100YamlSchemaDependencies {
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub env_dependencies_policy: Option<
-        SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy,
-    >,
+    pub env_dependencies_policy:
+        Option<SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sbom: Option<Vec<SecurityInsightsVersion100YamlSchemaDependenciesSbomItem>>,
     ///Define if the project uses third-party packages.
@@ -338,14 +334,14 @@ pub struct SecurityInsightsVersion100YamlSchemaDependencies {
     )]
     pub third_party_packages: Option<bool>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaDependencies {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaDependencies {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaDependencies {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaDependencies {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaDependencies {
         builder::SecurityInsightsVersion100YamlSchemaDependencies::default()
     }
 }
@@ -354,107 +350,102 @@ impl SecurityInsightsVersion100YamlSchemaDependencies {
 pub struct SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
     ///Summary about the dependencies lifecycle policy, third-party packages updating process, and deprecation process. Maximum length 560 chars.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub comment: Option<
-        SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment,
-    >,
+    pub comment:
+        Option<SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment>,
     ///Link to the dependencies lifecycle policy.
-    #[serde(rename = "policy-url", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "policy-url",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub policy_url: Option<String>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
+    #[must_use]
+    pub fn builder(
+    ) -> builder::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
         builder::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle::default()
     }
 }
 ///Summary about the dependencies lifecycle policy, third-party packages updating process, and deprecation process. Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
-pub struct SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment(
-    String,
-);
+pub struct SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment(String);
 impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment
+{
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment>
-for String {
+impl From<SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment> for String {
     fn from(
         value: SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment,
     ) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment
+{
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -462,217 +453,207 @@ for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment
 pub struct SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
     ///Summary about how third-party dependencies are adopted and consumed in the different environments (dev, test, prod). Maximum length 560 chars.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub comment: Option<
-        SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment,
-    >,
+    pub comment:
+        Option<SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment>,
     ///Link to the enviroment dependencies policy.
-    #[serde(rename = "policy-url", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "policy-url",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub policy_url: Option<String>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
+    #[must_use]
+    pub fn builder(
+    ) -> builder::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
         builder::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy::default()
     }
 }
 ///Summary about how third-party dependencies are adopted and consumed in the different environments (dev, test, prod). Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
-pub struct SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment(
-    String,
-);
+pub struct SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment(String);
 impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment
+{
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment>
-for String {
+impl From<SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment> for String {
     fn from(
         value: SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment,
     ) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment
+{
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment {
+    for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
     ///Description of how the SBOM is created. Maximum length 560 characters.
-    #[serde(rename = "sbom-creation", default, skip_serializing_if = "Option::is_none")]
-    pub sbom_creation: Option<
-        SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation,
-    >,
+    #[serde(
+        rename = "sbom-creation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sbom_creation: Option<SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation>,
     ///Link to the SBOM file.
     #[serde(rename = "sbom-file", default, skip_serializing_if = "Option::is_none")]
     pub sbom_file: Option<String>,
     ///Name of the SBOM standard used.
-    #[serde(rename = "sbom-format", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "sbom-format",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub sbom_format: Option<String>,
     ///Link to the SBOM standard website or documentation.
     #[serde(rename = "sbom-url", default, skip_serializing_if = "Option::is_none")]
     pub sbom_url: Option<String>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
         builder::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem::default()
     }
 }
 ///Description of how the SBOM is created. Maximum length 560 characters.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation(String);
-impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
+impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation>
-for String {
-    fn from(
-        value: SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation,
-    ) -> Self {
+impl From<SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation> for String {
+    fn from(value: SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
+    for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
+    for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
+    for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation {
+    for SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -682,16 +663,28 @@ pub struct SecurityInsightsVersion100YamlSchemaHeader {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub changelog: Option<String>,
     ///The last commit to which the SECURITY-INSIGHTS.yml refers.
-    #[serde(rename = "commit-hash", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "commit-hash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub commit_hash: Option<SecurityInsightsVersion100YamlSchemaHeaderCommitHash>,
     ///Expiration date for the SECURITY-INSIGHTS.yml. At most a year later the `last-reviewed` date.
     #[serde(rename = "expiration-date")]
     pub expiration_date: chrono::DateTime<chrono::offset::Utc>,
     ///Last time the SECURITY-INSIGHTS.yml was reviewed. Updating this property requires updating the property `commit-hash`.
-    #[serde(rename = "last-reviewed", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "last-reviewed",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub last_reviewed: Option<chrono::DateTime<chrono::offset::Utc>>,
     ///Last time the SECURITY-INSIGHTS.yml was updated, excluding the properties `commit-hash` and `last-reviewed`.
-    #[serde(rename = "last-updated", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "last-updated",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub last_updated: Option<chrono::DateTime<chrono::offset::Utc>>,
     ///Link to the project license.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -710,29 +703,20 @@ pub struct SecurityInsightsVersion100YamlSchemaHeader {
     #[serde(rename = "schema-version")]
     pub schema_version: SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaHeader {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaHeader {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaHeader {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaHeader {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaHeader {
         builder::SecurityInsightsVersion100YamlSchemaHeader::default()
     }
 }
 ///The last commit to which the SECURITY-INSIGHTS.yml refers.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaHeaderCommitHash(String);
 impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
@@ -746,8 +730,7 @@ impl From<SecurityInsightsVersion100YamlSchemaHeaderCommitHash> for String {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
     fn from(value: &Self) -> Self {
         value.clone()
     }
@@ -755,44 +738,42 @@ for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
 impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^\\b[0-9a-f]{5,40}\\b$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^\\b[0-9a-f]{5,40}\\b$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^\\b[0-9a-f]{5,40}\\b$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
+impl std::convert::TryFrom<&str> for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
+impl std::convert::TryFrom<&String> for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
+impl std::convert::TryFrom<String> for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
+impl<'de> serde::Deserialize<'de> for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 ///Version of the SECURITY-INSIGHTS YAML Schema.
@@ -807,14 +788,13 @@ for SecurityInsightsVersion100YamlSchemaHeaderCommitHash {
     PartialEq,
     PartialOrd,
     Serialize,
-    schemars::JsonSchema
+    schemars::JsonSchema,
 )]
 pub enum SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
     #[serde(rename = "1.0.0")]
     _100,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
     fn from(value: &Self) -> Self {
         value.clone()
     }
@@ -835,22 +815,19 @@ impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersi
         }
     }
 }
-impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
+impl std::convert::TryFrom<&str> for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
+impl std::convert::TryFrom<&String> for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
+impl std::convert::TryFrom<String> for SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -870,7 +847,11 @@ pub struct SecurityInsightsVersion100YamlSchemaProjectLifecycle {
     )]
     pub core_maintainers: Option<Vec<String>>,
     ///Link to the project release cycle.
-    #[serde(rename = "release-cycle", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "release-cycle",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub release_cycle: Option<String>,
     ///Shortly describe the release process. Maximum length 560 chars.
     #[serde(
@@ -878,105 +859,92 @@ pub struct SecurityInsightsVersion100YamlSchemaProjectLifecycle {
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub release_process: Option<
-        SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess,
-    >,
+    pub release_process: Option<SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess>,
     ///Link to the project roadmap.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub roadmap: Option<String>,
     ///Define if the project is still active or not.
     pub status: SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycle {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaProjectLifecycle {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaProjectLifecycle {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaProjectLifecycle {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaProjectLifecycle {
         builder::SecurityInsightsVersion100YamlSchemaProjectLifecycle::default()
     }
 }
 ///Shortly describe the release process. Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess(String);
-impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
+impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess>
-for String {
-    fn from(
-        value: SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess,
-    ) -> Self {
+impl From<SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess> for String {
+    fn from(value: SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
+    for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
+    for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
+    for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
+    for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 ///Define if the project is still active or not.
@@ -991,7 +959,7 @@ for SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess {
     PartialEq,
     PartialOrd,
     Serialize,
-    schemars::JsonSchema
+    schemars::JsonSchema,
 )]
 pub enum SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
     #[serde(rename = "active")]
@@ -1011,8 +979,7 @@ pub enum SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
     #[serde(rename = "moved")]
     Moved,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
     fn from(value: &Self) -> Self {
         value.clone()
     }
@@ -1047,22 +1014,19 @@ impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaProjectLifecycleS
         }
     }
 }
-impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
+impl std::convert::TryFrom<&str> for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
+impl std::convert::TryFrom<&String> for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
-impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
+impl std::convert::TryFrom<String> for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -1071,29 +1035,34 @@ for SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus {
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
-    #[serde(rename = "other-artifacts", default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        rename = "other-artifacts",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub other_artifacts: Vec<serde_json::Value>,
     #[serde(
         rename = "self-assessment",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub self_assessment: Option<
-        SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment,
-    >,
-    #[serde(rename = "threat-model", default, skip_serializing_if = "Option::is_none")]
-    pub threat_model: Option<
-        SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel,
-    >,
+    pub self_assessment:
+        Option<SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment>,
+    #[serde(
+        rename = "threat-model",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub threat_model: Option<SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
         builder::SecurityInsightsVersion100YamlSchemaSecurityArtifacts::default()
     }
 }
@@ -1102,109 +1071,103 @@ impl SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
 pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
     ///Additional context regarding the security self assessment or its status. Maximum length 560 chars.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub comment: Option<
-        SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment,
-    >,
-    #[serde(rename = "evidence-url", default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment>,
+    #[serde(
+        rename = "evidence-url",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub evidence_url: Option<Vec<String>>,
     ///Define whether a security self assessment for the project has been created. A false value may be used to add comments regarding the status of the assessment.
     #[serde(rename = "self-assessment-created")]
     pub self_assessment_created: bool,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment
+    {
         builder::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment::default()
     }
 }
 ///Additional context regarding the security self assessment or its status. Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
-pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment(
-    String,
-);
+pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment(String);
 impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment
+{
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment>
-for String {
+impl From<SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment> for String {
     fn from(
         value: SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment,
     ) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment
+{
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -1212,109 +1175,98 @@ for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment {
 pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
     ///Additional comment to describe the threat models, giving more context. Maximum length 560 chars.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub comment: Option<
-        SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment,
-    >,
-    #[serde(rename = "evidence-url", default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment>,
+    #[serde(
+        rename = "evidence-url",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub evidence_url: Option<Vec<String>>,
     ///Define if the threat model for the project has been created.
     #[serde(rename = "threat-model-created")]
     pub threat_model_created: bool,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
         builder::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel::default()
     }
 }
 ///Additional comment to describe the threat models, giving more context. Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
-pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment(
-    String,
-);
-impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
+pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment(String);
+impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment>
-for String {
+impl From<SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment> for String {
     fn from(
         value: SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment,
     ) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -1324,112 +1276,101 @@ pub struct SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
     #[serde(rename = "auditor-name")]
     pub auditor_name: String,
     ///Link to the security report provided by the auditor.
-    #[serde(rename = "auditor-report", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "auditor-report",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub auditor_report: Option<String>,
     ///Link to the auditor website.
     #[serde(rename = "auditor-url")]
     pub auditor_url: String,
     ///Additional comment to describe the report giving more context. Maximum length 560 chars.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub comment: Option<
-        SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment,
-    >,
+    pub comment: Option<SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment>,
     ///Year of the report.
     #[serde(rename = "report-year")]
     pub report_year: i64,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
         builder::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem::default()
     }
 }
 ///Additional comment to describe the report giving more context. Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment(String);
-impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
+impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl From<SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment>
-for String {
-    fn from(
-        value: SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment,
-    ) -> Self {
+impl From<SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment> for String {
+    fn from(value: SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -1444,14 +1385,14 @@ pub struct SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
     ///Security contact.
     pub value: SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
         builder::SecurityInsightsVersion100YamlSchemaSecurityContactsItem::default()
     }
 }
@@ -1467,7 +1408,7 @@ impl SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
     PartialEq,
     PartialOrd,
     Serialize,
-    schemars::JsonSchema
+    schemars::JsonSchema,
 )]
 pub enum SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
     #[serde(rename = "email")]
@@ -1477,11 +1418,8 @@ pub enum SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
     #[serde(rename = "url")]
     Url,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
@@ -1505,22 +1443,23 @@ impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaSecurityContactsI
         }
     }
 }
-impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
+impl std::convert::TryFrom<&str> for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
+    for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
+    for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -1528,16 +1467,7 @@ for SecurityInsightsVersion100YamlSchemaSecurityContactsItemType {
 }
 ///Security contact.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue(String);
 impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
@@ -1547,30 +1477,24 @@ impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaSecurityContactsIte
     }
 }
 impl From<SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue> for String {
-    fn from(
-        value: SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue,
-    ) -> Self {
+    fn from(value: SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new(
-                "^[\\w+_.-]+@[\\w.-]+$|https?:\\/\\/|[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\\s\\./0-9]*$",
-            )
-            .unwrap()
-            .find(value)
-            .is_none()
+            "^[\\w+_.-]+@[\\w.-]+$|https?:\\/\\/|[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\\s\\./0-9]*$",
+        )
+        .unwrap()
+        .find(value)
+        .is_none()
         {
             return Err(
                 "doesn't match pattern \"^[\\w+_.-]+@[\\w.-]+$|https?:\\/\\/|[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\\s\\./0-9]*$\"",
@@ -1579,38 +1503,38 @@ for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
         Ok(Self(value.to_string()))
     }
 }
-impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
+impl std::convert::TryFrom<&str> for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
+    for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
+    for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue {
+    for SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -1623,7 +1547,11 @@ pub struct SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
     ///Name of the tool used to scan or analyze the project.
     #[serde(rename = "tool-name")]
     pub tool_name: String,
-    #[serde(rename = "tool-rulesets", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "tool-rulesets",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub tool_rulesets: Option<Vec<String>>,
     ///Type of security test: `sast`, `dast`, `iast`, `fuzzer` or `sca`.
     #[serde(rename = "tool-type")]
@@ -1635,29 +1563,20 @@ pub struct SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
     #[serde(rename = "tool-version")]
     pub tool_version: String,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
         builder::SecurityInsightsVersion100YamlSchemaSecurityTestingItem::default()
     }
 }
 ///Additional comment to describe the used tool, giving more context. Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment(String);
 impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
@@ -1667,62 +1586,62 @@ impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaSecurityTestingItem
     }
 }
 impl From<SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment> for String {
-    fn from(
-        value: SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment,
-    ) -> Self {
+    fn from(value: SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment {
+    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(Clone, Debug, Deserialize, Serialize, schemars::JsonSchema, ToSchema)]
@@ -1737,16 +1656,15 @@ pub struct SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
     ///Define if the security test is part of the CI.
     pub ci: bool,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration
+    {
         builder::SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration::default()
     }
 }
@@ -1762,7 +1680,7 @@ impl SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
     PartialEq,
     PartialOrd,
     Serialize,
-    schemars::JsonSchema
+    schemars::JsonSchema,
 )]
 pub enum SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
     #[serde(rename = "sast")]
@@ -1776,11 +1694,8 @@ pub enum SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
     #[serde(rename = "sca")]
     Sca,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
@@ -1795,8 +1710,7 @@ impl ToString for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolTyp
         }
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -1810,21 +1724,24 @@ for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
+    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
+    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType {
+    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -1844,31 +1761,33 @@ pub struct SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
     )]
     pub bug_bounty_available: Option<bool>,
     ///Link to the bug bounty program.
-    #[serde(rename = "bug-bounty-url", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "bug-bounty-url",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub bug_bounty_url: Option<String>,
     ///Additional comment to describe the in-scope list, out-scope list, preferred contact method, or other context. Maximum length 560 chars.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub comment: Option<
-        SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment,
-    >,
+    pub comment: Option<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment>,
     ///E-mail contact to report vulnerabilities or other related information.
-    #[serde(rename = "email-contact", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "email-contact",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub email_contact: Option<String>,
     ///In-scope vulnerability categories, according to OWASP Top 10 2021. It is recommended to specify a better in-scope list in the security policy.
     #[serde(rename = "in-scope", default, skip_serializing_if = "Option::is_none")]
-    pub in_scope: Option<
-        Vec<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem>,
-    >,
+    pub in_scope:
+        Option<Vec<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem>>,
     ///Out-of-scope vulnerability categories, according to OWASP Top 10 2021. It is recommended to specify a better out-of-scope list in the security policy.
     #[serde(rename = "out-scope", default, skip_serializing_if = "Option::is_none")]
-    pub out_scope: Option<
-        Vec<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem>,
-    >,
+    pub out_scope:
+        Option<Vec<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem>>,
     ///PGP Public Key.
     #[serde(rename = "pgp-key", default, skip_serializing_if = "Option::is_none")]
-    pub pgp_key: Option<
-        SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey,
-    >,
+    pub pgp_key: Option<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey>,
     ///Link to the security policy.
     #[serde(
         rename = "security-policy",
@@ -1877,95 +1796,85 @@ pub struct SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
     )]
     pub security_policy: Option<String>,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
     fn from(value: &Self) -> Self {
         value.clone()
     }
 }
 impl SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
-    #[must_use] pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
+    #[must_use]
+    pub fn builder() -> builder::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
         builder::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting::default()
     }
 }
 ///Additional comment to describe the in-scope list, out-scope list, preferred contact method, or other context. Maximum length 560 chars.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment(String);
-impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
+impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
 impl From<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment> for String {
-    fn from(
-        value: SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment,
-    ) -> Self {
+    fn from(value: SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
-        if regress::Regex::new("^(.|\\n){1,560}$").unwrap().find(value).is_none() {
+        if regress::Regex::new("^(.|\\n){1,560}$")
+            .unwrap()
+            .find(value)
+            .is_none()
+        {
             return Err("doesn't match pattern \"^(.|\\n){1,560}$\"");
         }
         Ok(Self(value.to_string()))
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 #[derive(
@@ -1979,7 +1888,7 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment {
     PartialEq,
     PartialOrd,
     Serialize,
-    schemars::JsonSchema
+    schemars::JsonSchema,
 )]
 pub enum SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
     #[serde(rename = "broken access control")]
@@ -2005,11 +1914,8 @@ pub enum SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
     #[serde(rename = "other")]
     Other,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
@@ -2038,8 +1944,7 @@ impl ToString for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInSc
         }
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -2048,15 +1953,11 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
             "injection" => Ok(Self::Injection),
             "insecure design" => Ok(Self::InsecureDesign),
             "security misconfiguration" => Ok(Self::SecurityMisconfiguration),
-            "vulnerable and outdated components" => {
-                Ok(Self::VulnerableAndOutdatedComponents)
-            }
+            "vulnerable and outdated components" => Ok(Self::VulnerableAndOutdatedComponents),
             "identification and authentication failures" => {
                 Ok(Self::IdentificationAndAuthenticationFailures)
             }
-            "software and data integrity failures" => {
-                Ok(Self::SoftwareAndDataIntegrityFailures)
-            }
+            "software and data integrity failures" => Ok(Self::SoftwareAndDataIntegrityFailures),
             "security logging and monitoring failures" => {
                 Ok(Self::SecurityLoggingAndMonitoringFailures)
             }
@@ -2067,21 +1968,24 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -2098,7 +2002,7 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem {
     PartialEq,
     PartialOrd,
     Serialize,
-    schemars::JsonSchema
+    schemars::JsonSchema,
 )]
 pub enum SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
     #[serde(rename = "broken access control")]
@@ -2124,16 +2028,12 @@ pub enum SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem 
     #[serde(rename = "other")]
     Other,
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl ToString
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
+impl ToString for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
     fn to_string(&self) -> String {
         match *self {
             Self::BrokenAccessControl => "broken access control".to_string(),
@@ -2158,8 +2058,7 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
         }
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         match value {
@@ -2168,15 +2067,11 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
             "injection" => Ok(Self::Injection),
             "insecure design" => Ok(Self::InsecureDesign),
             "security misconfiguration" => Ok(Self::SecurityMisconfiguration),
-            "vulnerable and outdated components" => {
-                Ok(Self::VulnerableAndOutdatedComponents)
-            }
+            "vulnerable and outdated components" => Ok(Self::VulnerableAndOutdatedComponents),
             "identification and authentication failures" => {
                 Ok(Self::IdentificationAndAuthenticationFailures)
             }
-            "software and data integrity failures" => {
-                Ok(Self::SoftwareAndDataIntegrityFailures)
-            }
+            "software and data integrity failures" => Ok(Self::SoftwareAndDataIntegrityFailures),
             "security logging and monitoring failures" => {
                 Ok(Self::SecurityLoggingAndMonitoringFailures)
             }
@@ -2187,21 +2082,24 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
@@ -2209,42 +2107,26 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem {
 }
 ///PGP Public Key.
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    schemars::JsonSchema,
-    ToSchema
+    Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, schemars::JsonSchema, ToSchema,
 )]
 pub struct SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey(String);
-impl std::ops::Deref
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
+impl std::ops::Deref for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
     type Target = String;
     fn deref(&self) -> &String {
         &self.0
     }
 }
 impl From<SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey> for String {
-    fn from(
-        value: SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey,
-    ) -> Self {
+    fn from(value: SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey) -> Self {
         value.0
     }
 }
-impl From<&Self>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
-    fn from(
-        value: &Self,
-    ) -> Self {
+impl From<&Self> for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
+    fn from(value: &Self) -> Self {
         value.clone()
     }
 }
-impl std::str::FromStr
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
+impl std::str::FromStr for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
     type Err = &'static str;
     fn from_str(value: &str) -> Result<Self, &'static str> {
         if regress::Regex::new(
@@ -2262,103 +2144,81 @@ for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
     }
 }
 impl std::convert::TryFrom<&str>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey
+{
     type Error = &'static str;
     fn try_from(value: &str) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<&String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey
+{
     type Error = &'static str;
     fn try_from(value: &String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl std::convert::TryFrom<String>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey
+{
     type Error = &'static str;
     fn try_from(value: String) -> Result<Self, &'static str> {
         value.parse()
     }
 }
 impl<'de> serde::Deserialize<'de>
-for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey {
+    for SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey
+{
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer)?
             .parse()
-            .map_err(|e: &'static str| {
-                <D::Error as serde::de::Error>::custom(e.to_string())
-            })
+            .map_err(|e: &'static str| <D::Error as serde::de::Error>::custom(e.to_string()))
     }
 }
 pub mod builder {
     #[derive(Clone, Debug)]
     pub struct SecurityInsightsVersion100YamlSchema {
-        contribution_policy: Result<
-            super::SecurityInsightsVersion100YamlSchemaContributionPolicy,
-            String,
-        >,
-        dependencies: Result<
-            Option<super::SecurityInsightsVersion100YamlSchemaDependencies>,
-            String,
-        >,
+        contribution_policy:
+            Result<super::SecurityInsightsVersion100YamlSchemaContributionPolicy, String>,
+        dependencies:
+            Result<Option<super::SecurityInsightsVersion100YamlSchemaDependencies>, String>,
         distribution_points: Result<Vec<String>, String>,
         documentation: Result<Option<Vec<String>>, String>,
         header: Result<super::SecurityInsightsVersion100YamlSchemaHeader, String>,
-        project_lifecycle: Result<
-            super::SecurityInsightsVersion100YamlSchemaProjectLifecycle,
-            String,
-        >,
-        security_artifacts: Result<
-            Option<super::SecurityInsightsVersion100YamlSchemaSecurityArtifacts>,
-            String,
-        >,
+        project_lifecycle:
+            Result<super::SecurityInsightsVersion100YamlSchemaProjectLifecycle, String>,
+        security_artifacts:
+            Result<Option<super::SecurityInsightsVersion100YamlSchemaSecurityArtifacts>, String>,
         security_assessments: Result<
-            Option<
-                Vec<super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem>,
-            >,
+            Option<Vec<super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem>>,
             String,
         >,
-        security_contacts: Result<
-            Vec<super::SecurityInsightsVersion100YamlSchemaSecurityContactsItem>,
-            String,
-        >,
-        security_testing: Result<
-            Vec<super::SecurityInsightsVersion100YamlSchemaSecurityTestingItem>,
-            String,
-        >,
-        vulnerability_reporting: Result<
-            super::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting,
-            String,
-        >,
+        security_contacts:
+            Result<Vec<super::SecurityInsightsVersion100YamlSchemaSecurityContactsItem>, String>,
+        security_testing:
+            Result<Vec<super::SecurityInsightsVersion100YamlSchemaSecurityTestingItem>, String>,
+        vulnerability_reporting:
+            Result<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting, String>,
     }
     impl Default for SecurityInsightsVersion100YamlSchema {
         fn default() -> Self {
             Self {
-                contribution_policy: Err(
-                    "no value supplied for contribution_policy".to_string(),
-                ),
+                contribution_policy: Err("no value supplied for contribution_policy".to_string()),
                 dependencies: Ok(Default::default()),
-                distribution_points: Err(
-                    "no value supplied for distribution_points".to_string(),
-                ),
+                distribution_points: Err("no value supplied for distribution_points".to_string()),
                 documentation: Ok(Default::default()),
                 header: Err("no value supplied for header".to_string()),
-                project_lifecycle: Err(
-                    "no value supplied for project_lifecycle".to_string(),
-                ),
+                project_lifecycle: Err("no value supplied for project_lifecycle".to_string()),
                 security_artifacts: Ok(Default::default()),
                 security_assessments: Ok(Default::default()),
-                security_contacts: Err(
-                    "no value supplied for security_contacts".to_string(),
-                ),
+                security_contacts: Err("no value supplied for security_contacts".to_string()),
                 security_testing: Ok(Default::default()),
                 vulnerability_reporting: Err(
-                    "no value supplied for vulnerability_reporting".to_string(),
+                    "no value supplied for vulnerability_reporting".to_string()
                 ),
             }
         }
@@ -2366,19 +2226,12 @@ pub mod builder {
     impl SecurityInsightsVersion100YamlSchema {
         pub fn contribution_policy<T>(mut self, value: T) -> Self
         where
-            T: std::convert::TryInto<
-                super::SecurityInsightsVersion100YamlSchemaContributionPolicy,
-            >,
+            T: std::convert::TryInto<super::SecurityInsightsVersion100YamlSchemaContributionPolicy>,
             T::Error: std::fmt::Display,
         {
-            self
-                .contribution_policy = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for contribution_policy: {e}"
-                    )
-                });
+            self.contribution_policy = value.try_into().map_err(|e| {
+                format!("error converting supplied value for contribution_policy: {e}")
+            });
             self
         }
         pub fn dependencies<T>(mut self, value: T) -> Self
@@ -2388,12 +2241,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .dependencies = value
+            self.dependencies = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for dependencies: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for dependencies: {e}"));
             self
         }
         pub fn distribution_points<T>(mut self, value: T) -> Self
@@ -2401,14 +2251,9 @@ pub mod builder {
             T: std::convert::TryInto<Vec<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .distribution_points = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for distribution_points: {e}"
-                    )
-                });
+            self.distribution_points = value.try_into().map_err(|e| {
+                format!("error converting supplied value for distribution_points: {e}")
+            });
             self
         }
         pub fn documentation<T>(mut self, value: T) -> Self
@@ -2416,12 +2261,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<Vec<String>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .documentation = value
+            self.documentation = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for documentation: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for documentation: {e}"));
             self
         }
         pub fn header<T>(mut self, value: T) -> Self
@@ -2429,29 +2271,19 @@ pub mod builder {
             T: std::convert::TryInto<super::SecurityInsightsVersion100YamlSchemaHeader>,
             T::Error: std::fmt::Display,
         {
-            self
-                .header = value
+            self.header = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for header: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for header: {e}"));
             self
         }
         pub fn project_lifecycle<T>(mut self, value: T) -> Self
         where
-            T: std::convert::TryInto<
-                super::SecurityInsightsVersion100YamlSchemaProjectLifecycle,
-            >,
+            T: std::convert::TryInto<super::SecurityInsightsVersion100YamlSchemaProjectLifecycle>,
             T::Error: std::fmt::Display,
         {
-            self
-                .project_lifecycle = value
+            self.project_lifecycle = value
                 .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for project_lifecycle: {e}"
-                    )
-                });
+                .map_err(|e| format!("error converting supplied value for project_lifecycle: {e}"));
             self
         }
         pub fn security_artifacts<T>(mut self, value: T) -> Self
@@ -2461,35 +2293,21 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .security_artifacts = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for security_artifacts: {e}"
-                    )
-                });
+            self.security_artifacts = value.try_into().map_err(|e| {
+                format!("error converting supplied value for security_artifacts: {e}")
+            });
             self
         }
         pub fn security_assessments<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    Vec<
-                        super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem,
-                    >,
-                >,
+                Option<Vec<super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem>>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .security_assessments = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for security_assessments: {e}"
-                    )
-                });
+            self.security_assessments = value.try_into().map_err(|e| {
+                format!("error converting supplied value for security_assessments: {e}")
+            });
             self
         }
         pub fn security_contacts<T>(mut self, value: T) -> Self
@@ -2499,14 +2317,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .security_contacts = value
+            self.security_contacts = value
                 .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for security_contacts: {e}"
-                    )
-                });
+                .map_err(|e| format!("error converting supplied value for security_contacts: {e}"));
             self
         }
         pub fn security_testing<T>(mut self, value: T) -> Self
@@ -2516,14 +2329,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .security_testing = value
+            self.security_testing = value
                 .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for security_testing: {e}"
-                    )
-                });
+                .map_err(|e| format!("error converting supplied value for security_testing: {e}"));
             self
         }
         pub fn vulnerability_reporting<T>(mut self, value: T) -> Self
@@ -2533,23 +2341,17 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .vulnerability_reporting = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for vulnerability_reporting: {e}"
-                    )
-                });
+            self.vulnerability_reporting = value.try_into().map_err(|e| {
+                format!("error converting supplied value for vulnerability_reporting: {e}")
+            });
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchema>
-    for super::SecurityInsightsVersion100YamlSchema {
+        for super::SecurityInsightsVersion100YamlSchema
+    {
         type Error = String;
-        fn try_from(
-            value: SecurityInsightsVersion100YamlSchema,
-        ) -> Result<Self, String> {
+        fn try_from(value: SecurityInsightsVersion100YamlSchema) -> Result<Self, String> {
             Ok(Self {
                 contribution_policy: value.contribution_policy?,
                 dependencies: value.dependencies?,
@@ -2565,8 +2367,7 @@ pub mod builder {
             })
         }
     }
-    impl From<super::SecurityInsightsVersion100YamlSchema>
-    for SecurityInsightsVersion100YamlSchema {
+    impl From<super::SecurityInsightsVersion100YamlSchema> for SecurityInsightsVersion100YamlSchema {
         fn from(value: super::SecurityInsightsVersion100YamlSchema) -> Self {
             Self {
                 contribution_policy: Ok(value.contribution_policy),
@@ -2605,7 +2406,7 @@ pub mod builder {
                     "no value supplied for accepts_automated_pull_requests".to_string(),
                 ),
                 accepts_pull_requests: Err(
-                    "no value supplied for accepts_pull_requests".to_string(),
+                    "no value supplied for accepts_pull_requests".to_string()
                 ),
                 automated_tools_list: Ok(Default::default()),
                 code_of_conduct: Ok(Default::default()),
@@ -2619,14 +2420,9 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .accepts_automated_pull_requests = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for accepts_automated_pull_requests: {e}"
-                    )
-                });
+            self.accepts_automated_pull_requests = value.try_into().map_err(|e| {
+                format!("error converting supplied value for accepts_automated_pull_requests: {e}")
+            });
             self
         }
         pub fn accepts_pull_requests<T>(mut self, value: T) -> Self
@@ -2634,14 +2430,9 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .accepts_pull_requests = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for accepts_pull_requests: {e}"
-                    )
-                });
+            self.accepts_pull_requests = value.try_into().map_err(|e| {
+                format!("error converting supplied value for accepts_pull_requests: {e}")
+            });
             self
         }
         pub fn automated_tools_list<T>(mut self, value: T) -> Self
@@ -2655,14 +2446,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .automated_tools_list = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for automated_tools_list: {e}"
-                    )
-                });
+            self.automated_tools_list = value.try_into().map_err(|e| {
+                format!("error converting supplied value for automated_tools_list: {e}")
+            });
             self
         }
         pub fn code_of_conduct<T>(mut self, value: T) -> Self
@@ -2670,12 +2456,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .code_of_conduct = value
+            self.code_of_conduct = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for code_of_conduct: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for code_of_conduct: {e}"));
             self
         }
         pub fn contributing_policy<T>(mut self, value: T) -> Self
@@ -2683,19 +2466,15 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .contributing_policy = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for contributing_policy: {e}"
-                    )
-                });
+            self.contributing_policy = value.try_into().map_err(|e| {
+                format!("error converting supplied value for contributing_policy: {e}")
+            });
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaContributionPolicy>
-    for super::SecurityInsightsVersion100YamlSchemaContributionPolicy {
+        for super::SecurityInsightsVersion100YamlSchemaContributionPolicy
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaContributionPolicy,
@@ -2710,14 +2489,11 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaContributionPolicy>
-    for SecurityInsightsVersion100YamlSchemaContributionPolicy {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaContributionPolicy,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaContributionPolicy
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaContributionPolicy) -> Self {
             Self {
-                accepts_automated_pull_requests: Ok(
-                    value.accepts_automated_pull_requests,
-                ),
+                accepts_automated_pull_requests: Ok(value.accepts_automated_pull_requests),
                 accepts_pull_requests: Ok(value.accepts_pull_requests),
                 automated_tools_list: Ok(value.automated_tools_list),
                 code_of_conduct: Ok(value.code_of_conduct),
@@ -2740,8 +2516,7 @@ pub mod builder {
         >,
         path: Result<Option<Vec<String>>, String>,
     }
-    impl Default
-    for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
+    impl Default for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
         fn default() -> Self {
             Self {
                 action: Err("no value supplied for action".to_string()),
@@ -2759,12 +2534,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .action = value
+            self.action = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for action: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for action: {e}"));
             self
         }
         pub fn automated_tool<T>(mut self, value: T) -> Self
@@ -2772,12 +2544,9 @@ pub mod builder {
             T: std::convert::TryInto<String>,
             T::Error: std::fmt::Display,
         {
-            self
-                .automated_tool = value
+            self.automated_tool = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for automated_tool: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for automated_tool: {e}"));
             self
         }
         pub fn comment<T>(mut self, value: T) -> Self
@@ -2789,12 +2558,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn path<T>(mut self, value: T) -> Self
@@ -2802,17 +2568,17 @@ pub mod builder {
             T: std::convert::TryInto<Option<Vec<String>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .path = value
+            self.path = value
                 .try_into()
                 .map_err(|e| format!("error converting supplied value for path: {e}"));
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem,
-    >
-    for super::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
+    impl
+        std::convert::TryFrom<
+            SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem,
+        > for super::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem,
@@ -2825,9 +2591,9 @@ pub mod builder {
             })
         }
     }
-    impl From<
-        super::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem,
-    > for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem {
+    impl From<super::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem>
+        for SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem
+    {
         fn from(
             value: super::SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem,
         ) -> Self {
@@ -2842,16 +2608,12 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct SecurityInsightsVersion100YamlSchemaDependencies {
         dependencies_lifecycle: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle>,
             String,
         >,
         dependencies_lists: Result<Vec<String>, String>,
         env_dependencies_policy: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy>,
             String,
         >,
         sbom: Result<
@@ -2881,14 +2643,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .dependencies_lifecycle = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for dependencies_lifecycle: {e}"
-                    )
-                });
+            self.dependencies_lifecycle = value.try_into().map_err(|e| {
+                format!("error converting supplied value for dependencies_lifecycle: {e}")
+            });
             self
         }
         pub fn dependencies_lists<T>(mut self, value: T) -> Self
@@ -2896,14 +2653,9 @@ pub mod builder {
             T: std::convert::TryInto<Vec<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .dependencies_lists = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for dependencies_lists: {e}"
-                    )
-                });
+            self.dependencies_lists = value.try_into().map_err(|e| {
+                format!("error converting supplied value for dependencies_lists: {e}")
+            });
             self
         }
         pub fn env_dependencies_policy<T>(mut self, value: T) -> Self
@@ -2915,27 +2667,19 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .env_dependencies_policy = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for env_dependencies_policy: {e}"
-                    )
-                });
+            self.env_dependencies_policy = value.try_into().map_err(|e| {
+                format!("error converting supplied value for env_dependencies_policy: {e}")
+            });
             self
         }
         pub fn sbom<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    Vec<super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem>,
-                >,
+                Option<Vec<super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem>>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .sbom = value
+            self.sbom = value
                 .try_into()
                 .map_err(|e| format!("error converting supplied value for sbom: {e}"));
             self
@@ -2945,19 +2689,15 @@ pub mod builder {
             T: std::convert::TryInto<Option<bool>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .third_party_packages = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for third_party_packages: {e}"
-                    )
-                });
+            self.third_party_packages = value.try_into().map_err(|e| {
+                format!("error converting supplied value for third_party_packages: {e}")
+            });
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaDependencies>
-    for super::SecurityInsightsVersion100YamlSchemaDependencies {
+        for super::SecurityInsightsVersion100YamlSchemaDependencies
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaDependencies,
@@ -2972,7 +2712,8 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaDependencies>
-    for SecurityInsightsVersion100YamlSchemaDependencies {
+        for SecurityInsightsVersion100YamlSchemaDependencies
+    {
         fn from(value: super::SecurityInsightsVersion100YamlSchemaDependencies) -> Self {
             Self {
                 dependencies_lifecycle: Ok(value.dependencies_lifecycle),
@@ -2993,8 +2734,7 @@ pub mod builder {
         >,
         policy_url: Result<Option<String>, String>,
     }
-    impl Default
-    for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
+    impl Default for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
         fn default() -> Self {
             Self {
                 comment: Ok(Default::default()),
@@ -3012,12 +2752,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn policy_url<T>(mut self, value: T) -> Self
@@ -3025,18 +2762,16 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .policy_url = value
+            self.policy_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for policy_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for policy_url: {e}"));
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle,
-    > for super::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
+    impl
+        std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle>
+        for super::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle,
@@ -3047,9 +2782,9 @@ pub mod builder {
             })
         }
     }
-    impl From<
-        super::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle,
-    > for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle {
+    impl From<super::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle>
+        for SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle
+    {
         fn from(
             value: super::SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle,
         ) -> Self {
@@ -3069,8 +2804,7 @@ pub mod builder {
         >,
         policy_url: Result<Option<String>, String>,
     }
-    impl Default
-    for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
+    impl Default for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
         fn default() -> Self {
             Self {
                 comment: Ok(Default::default()),
@@ -3088,12 +2822,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn policy_url<T>(mut self, value: T) -> Self
@@ -3101,18 +2832,16 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .policy_url = value
+            self.policy_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for policy_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for policy_url: {e}"));
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy,
-    > for super::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
+    impl
+        std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy>
+        for super::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy,
@@ -3123,9 +2852,9 @@ pub mod builder {
             })
         }
     }
-    impl From<
-        super::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy,
-    > for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy {
+    impl From<super::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy>
+        for SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy
+    {
         fn from(
             value: super::SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy,
         ) -> Self {
@@ -3138,9 +2867,7 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
         sbom_creation: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation>,
             String,
         >,
         sbom_file: Result<Option<String>, String>,
@@ -3161,18 +2888,13 @@ pub mod builder {
         pub fn sbom_creation<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .sbom_creation = value
+            self.sbom_creation = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for sbom_creation: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for sbom_creation: {e}"));
             self
         }
         pub fn sbom_file<T>(mut self, value: T) -> Self
@@ -3180,12 +2902,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .sbom_file = value
+            self.sbom_file = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for sbom_file: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for sbom_file: {e}"));
             self
         }
         pub fn sbom_format<T>(mut self, value: T) -> Self
@@ -3193,12 +2912,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .sbom_format = value
+            self.sbom_format = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for sbom_format: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for sbom_format: {e}"));
             self
         }
         pub fn sbom_url<T>(mut self, value: T) -> Self
@@ -3206,17 +2922,15 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .sbom_url = value
+            self.sbom_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for sbom_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for sbom_url: {e}"));
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaDependenciesSbomItem>
-    for super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
+        for super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaDependenciesSbomItem,
@@ -3230,10 +2944,9 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem>
-    for SecurityInsightsVersion100YamlSchemaDependenciesSbomItem {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaDependenciesSbomItem
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaDependenciesSbomItem) -> Self {
             Self {
                 sbom_creation: Ok(value.sbom_creation),
                 sbom_file: Ok(value.sbom_file),
@@ -3245,29 +2958,23 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct SecurityInsightsVersion100YamlSchemaHeader {
         changelog: Result<Option<String>, String>,
-        commit_hash: Result<
-            Option<super::SecurityInsightsVersion100YamlSchemaHeaderCommitHash>,
-            String,
-        >,
+        commit_hash:
+            Result<Option<super::SecurityInsightsVersion100YamlSchemaHeaderCommitHash>, String>,
         expiration_date: Result<chrono::DateTime<chrono::offset::Utc>, String>,
         last_reviewed: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         last_updated: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
         license: Result<Option<String>, String>,
         project_release: Result<Option<String>, String>,
         project_url: Result<String, String>,
-        schema_version: Result<
-            super::SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion,
-            String,
-        >,
+        schema_version:
+            Result<super::SecurityInsightsVersion100YamlSchemaHeaderSchemaVersion, String>,
     }
     impl Default for SecurityInsightsVersion100YamlSchemaHeader {
         fn default() -> Self {
             Self {
                 changelog: Ok(Default::default()),
                 commit_hash: Ok(Default::default()),
-                expiration_date: Err(
-                    "no value supplied for expiration_date".to_string(),
-                ),
+                expiration_date: Err("no value supplied for expiration_date".to_string()),
                 last_reviewed: Ok(Default::default()),
                 last_updated: Ok(Default::default()),
                 license: Ok(Default::default()),
@@ -3283,12 +2990,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .changelog = value
+            self.changelog = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for changelog: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for changelog: {e}"));
             self
         }
         pub fn commit_hash<T>(mut self, value: T) -> Self
@@ -3298,12 +3002,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .commit_hash = value
+            self.commit_hash = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for commit_hash: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for commit_hash: {e}"));
             self
         }
         pub fn expiration_date<T>(mut self, value: T) -> Self
@@ -3311,12 +3012,9 @@ pub mod builder {
             T: std::convert::TryInto<chrono::DateTime<chrono::offset::Utc>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .expiration_date = value
+            self.expiration_date = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for expiration_date: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for expiration_date: {e}"));
             self
         }
         pub fn last_reviewed<T>(mut self, value: T) -> Self
@@ -3324,12 +3022,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<chrono::DateTime<chrono::offset::Utc>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .last_reviewed = value
+            self.last_reviewed = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for last_reviewed: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for last_reviewed: {e}"));
             self
         }
         pub fn last_updated<T>(mut self, value: T) -> Self
@@ -3337,12 +3032,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<chrono::DateTime<chrono::offset::Utc>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .last_updated = value
+            self.last_updated = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for last_updated: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for last_updated: {e}"));
             self
         }
         pub fn license<T>(mut self, value: T) -> Self
@@ -3350,12 +3042,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .license = value
+            self.license = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for license: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for license: {e}"));
             self
         }
         pub fn project_release<T>(mut self, value: T) -> Self
@@ -3363,12 +3052,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .project_release = value
+            self.project_release = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for project_release: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for project_release: {e}"));
             self
         }
         pub fn project_url<T>(mut self, value: T) -> Self
@@ -3376,12 +3062,9 @@ pub mod builder {
             T: std::convert::TryInto<String>,
             T::Error: std::fmt::Display,
         {
-            self
-                .project_url = value
+            self.project_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for project_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for project_url: {e}"));
             self
         }
         pub fn schema_version<T>(mut self, value: T) -> Self
@@ -3391,21 +3074,17 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .schema_version = value
+            self.schema_version = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for schema_version: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for schema_version: {e}"));
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaHeader>
-    for super::SecurityInsightsVersion100YamlSchemaHeader {
+        for super::SecurityInsightsVersion100YamlSchemaHeader
+    {
         type Error = String;
-        fn try_from(
-            value: SecurityInsightsVersion100YamlSchemaHeader,
-        ) -> Result<Self, String> {
+        fn try_from(value: SecurityInsightsVersion100YamlSchemaHeader) -> Result<Self, String> {
             Ok(Self {
                 changelog: value.changelog?,
                 commit_hash: value.commit_hash?,
@@ -3420,7 +3099,8 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaHeader>
-    for SecurityInsightsVersion100YamlSchemaHeader {
+        for SecurityInsightsVersion100YamlSchemaHeader
+    {
         fn from(value: super::SecurityInsightsVersion100YamlSchemaHeader) -> Self {
             Self {
                 changelog: Ok(value.changelog),
@@ -3441,16 +3121,11 @@ pub mod builder {
         core_maintainers: Result<Option<Vec<String>>, String>,
         release_cycle: Result<Option<String>, String>,
         release_process: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess>,
             String,
         >,
         roadmap: Result<Option<String>, String>,
-        status: Result<
-            super::SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus,
-            String,
-        >,
+        status: Result<super::SecurityInsightsVersion100YamlSchemaProjectLifecycleStatus, String>,
     }
     impl Default for SecurityInsightsVersion100YamlSchemaProjectLifecycle {
         fn default() -> Self {
@@ -3470,12 +3145,9 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .bug_fixes_only = value
+            self.bug_fixes_only = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for bug_fixes_only: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for bug_fixes_only: {e}"));
             self
         }
         pub fn core_maintainers<T>(mut self, value: T) -> Self
@@ -3483,14 +3155,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<Vec<String>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .core_maintainers = value
+            self.core_maintainers = value
                 .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for core_maintainers: {e}"
-                    )
-                });
+                .map_err(|e| format!("error converting supplied value for core_maintainers: {e}"));
             self
         }
         pub fn release_cycle<T>(mut self, value: T) -> Self
@@ -3498,29 +3165,21 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .release_cycle = value
+            self.release_cycle = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for release_cycle: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for release_cycle: {e}"));
             self
         }
         pub fn release_process<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .release_process = value
+            self.release_process = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for release_process: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for release_process: {e}"));
             self
         }
         pub fn roadmap<T>(mut self, value: T) -> Self
@@ -3528,12 +3187,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .roadmap = value
+            self.roadmap = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for roadmap: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for roadmap: {e}"));
             self
         }
         pub fn status<T>(mut self, value: T) -> Self
@@ -3543,17 +3199,15 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .status = value
+            self.status = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for status: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for status: {e}"));
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaProjectLifecycle>
-    for super::SecurityInsightsVersion100YamlSchemaProjectLifecycle {
+        for super::SecurityInsightsVersion100YamlSchemaProjectLifecycle
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaProjectLifecycle,
@@ -3569,10 +3223,9 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaProjectLifecycle>
-    for SecurityInsightsVersion100YamlSchemaProjectLifecycle {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaProjectLifecycle,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaProjectLifecycle
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaProjectLifecycle) -> Self {
             Self {
                 bug_fixes_only: Ok(value.bug_fixes_only),
                 core_maintainers: Ok(value.core_maintainers),
@@ -3587,15 +3240,11 @@ pub mod builder {
     pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
         other_artifacts: Result<Vec<serde_json::Value>, String>,
         self_assessment: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment>,
             String,
         >,
         threat_model: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel>,
             String,
         >,
     }
@@ -3614,51 +3263,39 @@ pub mod builder {
             T: std::convert::TryInto<Vec<serde_json::Value>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .other_artifacts = value
+            self.other_artifacts = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for other_artifacts: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for other_artifacts: {e}"));
             self
         }
         pub fn self_assessment<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .self_assessment = value
+            self.self_assessment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for self_assessment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for self_assessment: {e}"));
             self
         }
         pub fn threat_model<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .threat_model = value
+            self.threat_model = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for threat_model: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for threat_model: {e}"));
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaSecurityArtifacts>
-    for super::SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
+        for super::SecurityInsightsVersion100YamlSchemaSecurityArtifacts
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaSecurityArtifacts,
@@ -3671,10 +3308,9 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaSecurityArtifacts>
-    for SecurityInsightsVersion100YamlSchemaSecurityArtifacts {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaSecurityArtifacts,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaSecurityArtifacts
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaSecurityArtifacts) -> Self {
             Self {
                 other_artifacts: Ok(value.other_artifacts),
                 self_assessment: Ok(value.self_assessment),
@@ -3693,14 +3329,13 @@ pub mod builder {
         evidence_url: Result<Option<Vec<String>>, String>,
         self_assessment_created: Result<bool, String>,
     }
-    impl Default
-    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
+    impl Default for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
         fn default() -> Self {
             Self {
                 comment: Ok(Default::default()),
                 evidence_url: Ok(Default::default()),
                 self_assessment_created: Err(
-                    "no value supplied for self_assessment_created".to_string(),
+                    "no value supplied for self_assessment_created".to_string()
                 ),
             }
         }
@@ -3715,12 +3350,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn evidence_url<T>(mut self, value: T) -> Self
@@ -3728,12 +3360,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<Vec<String>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .evidence_url = value
+            self.evidence_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for evidence_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for evidence_url: {e}"));
             self
         }
         pub fn self_assessment_created<T>(mut self, value: T) -> Self
@@ -3741,20 +3370,15 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .self_assessment_created = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for self_assessment_created: {e}"
-                    )
-                });
+            self.self_assessment_created = value.try_into().map_err(|e| {
+                format!("error converting supplied value for self_assessment_created: {e}")
+            });
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment,
-    > for super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
+    impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment>
+        for super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment,
@@ -3767,7 +3391,8 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment>
-    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment {
+        for SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment
+    {
         fn from(
             value: super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment,
         ) -> Self {
@@ -3781,9 +3406,7 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
         comment: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment>,
             String,
         >,
         evidence_url: Result<Option<Vec<String>>, String>,
@@ -3794,9 +3417,7 @@ pub mod builder {
             Self {
                 comment: Ok(Default::default()),
                 evidence_url: Ok(Default::default()),
-                threat_model_created: Err(
-                    "no value supplied for threat_model_created".to_string(),
-                ),
+                threat_model_created: Err("no value supplied for threat_model_created".to_string()),
             }
         }
     }
@@ -3810,12 +3431,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn evidence_url<T>(mut self, value: T) -> Self
@@ -3823,12 +3441,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<Vec<String>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .evidence_url = value
+            self.evidence_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for evidence_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for evidence_url: {e}"));
             self
         }
         pub fn threat_model_created<T>(mut self, value: T) -> Self
@@ -3836,20 +3451,15 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .threat_model_created = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for threat_model_created: {e}"
-                    )
-                });
+            self.threat_model_created = value.try_into().map_err(|e| {
+                format!("error converting supplied value for threat_model_created: {e}")
+            });
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel,
-    > for super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
+    impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel>
+        for super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel,
@@ -3862,7 +3472,8 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel>
-    for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel {
+        for SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel
+    {
         fn from(
             value: super::SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel,
         ) -> Self {
@@ -3879,9 +3490,7 @@ pub mod builder {
         auditor_report: Result<Option<String>, String>,
         auditor_url: Result<String, String>,
         comment: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment>,
             String,
         >,
         report_year: Result<i64, String>,
@@ -3903,12 +3512,9 @@ pub mod builder {
             T: std::convert::TryInto<String>,
             T::Error: std::fmt::Display,
         {
-            self
-                .auditor_name = value
+            self.auditor_name = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for auditor_name: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for auditor_name: {e}"));
             self
         }
         pub fn auditor_report<T>(mut self, value: T) -> Self
@@ -3916,12 +3522,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .auditor_report = value
+            self.auditor_report = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for auditor_report: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for auditor_report: {e}"));
             self
         }
         pub fn auditor_url<T>(mut self, value: T) -> Self
@@ -3929,29 +3532,21 @@ pub mod builder {
             T: std::convert::TryInto<String>,
             T::Error: std::fmt::Display,
         {
-            self
-                .auditor_url = value
+            self.auditor_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for auditor_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for auditor_url: {e}"));
             self
         }
         pub fn comment<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn report_year<T>(mut self, value: T) -> Self
@@ -3959,18 +3554,15 @@ pub mod builder {
             T: std::convert::TryInto<i64>,
             T::Error: std::fmt::Display,
         {
-            self
-                .report_year = value
+            self.report_year = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for report_year: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for report_year: {e}"));
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem,
-    > for super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
+    impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem>
+        for super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem,
@@ -3985,10 +3577,9 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem>
-    for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem) -> Self {
             Self {
                 auditor_name: Ok(value.auditor_name),
                 auditor_report: Ok(value.auditor_report),
@@ -4001,14 +3592,8 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
         primary: Result<Option<bool>, String>,
-        type_: Result<
-            super::SecurityInsightsVersion100YamlSchemaSecurityContactsItemType,
-            String,
-        >,
-        value: Result<
-            super::SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue,
-            String,
-        >,
+        type_: Result<super::SecurityInsightsVersion100YamlSchemaSecurityContactsItemType, String>,
+        value: Result<super::SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue, String>,
     }
     impl Default for SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
         fn default() -> Self {
@@ -4025,12 +3610,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<bool>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .primary = value
+            self.primary = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for primary: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for primary: {e}"));
             self
         }
         pub fn type_<T>(mut self, value: T) -> Self
@@ -4040,12 +3622,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .type_ = value
+            self.type_ = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for type_: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for type_: {e}"));
             self
         }
         pub fn value<T>(mut self, value: T) -> Self
@@ -4055,17 +3634,15 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .value = value
+            self.value = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for value: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for value: {e}"));
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaSecurityContactsItem>
-    for super::SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
+        for super::SecurityInsightsVersion100YamlSchemaSecurityContactsItem
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaSecurityContactsItem,
@@ -4078,10 +3655,9 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaSecurityContactsItem>
-    for SecurityInsightsVersion100YamlSchemaSecurityContactsItem {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaSecurityContactsItem,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaSecurityContactsItem
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaSecurityContactsItem) -> Self {
             Self {
                 primary: Ok(value.primary),
                 type_: Ok(value.type_),
@@ -4092,9 +3668,7 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
         comment: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment>,
             String,
         >,
         integration: Result<
@@ -4103,10 +3677,8 @@ pub mod builder {
         >,
         tool_name: Result<String, String>,
         tool_rulesets: Result<Option<Vec<String>>, String>,
-        tool_type: Result<
-            super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType,
-            String,
-        >,
+        tool_type:
+            Result<super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemToolType, String>,
         tool_url: Result<Option<String>, String>,
         tool_version: Result<String, String>,
     }
@@ -4127,18 +3699,13 @@ pub mod builder {
         pub fn comment<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn integration<T>(mut self, value: T) -> Self
@@ -4148,12 +3715,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .integration = value
+            self.integration = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for integration: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for integration: {e}"));
             self
         }
         pub fn tool_name<T>(mut self, value: T) -> Self
@@ -4161,12 +3725,9 @@ pub mod builder {
             T: std::convert::TryInto<String>,
             T::Error: std::fmt::Display,
         {
-            self
-                .tool_name = value
+            self.tool_name = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for tool_name: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for tool_name: {e}"));
             self
         }
         pub fn tool_rulesets<T>(mut self, value: T) -> Self
@@ -4174,12 +3735,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<Vec<String>>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .tool_rulesets = value
+            self.tool_rulesets = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for tool_rulesets: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for tool_rulesets: {e}"));
             self
         }
         pub fn tool_type<T>(mut self, value: T) -> Self
@@ -4189,12 +3747,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .tool_type = value
+            self.tool_type = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for tool_type: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for tool_type: {e}"));
             self
         }
         pub fn tool_url<T>(mut self, value: T) -> Self
@@ -4202,12 +3757,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .tool_url = value
+            self.tool_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for tool_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for tool_url: {e}"));
             self
         }
         pub fn tool_version<T>(mut self, value: T) -> Self
@@ -4215,17 +3767,15 @@ pub mod builder {
             T: std::convert::TryInto<String>,
             T::Error: std::fmt::Display,
         {
-            self
-                .tool_version = value
+            self.tool_version = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for tool_version: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for tool_version: {e}"));
             self
         }
     }
     impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaSecurityTestingItem>
-    for super::SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
+        for super::SecurityInsightsVersion100YamlSchemaSecurityTestingItem
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaSecurityTestingItem,
@@ -4242,10 +3792,9 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaSecurityTestingItem>
-    for SecurityInsightsVersion100YamlSchemaSecurityTestingItem {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaSecurityTestingItem,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaSecurityTestingItem
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaSecurityTestingItem) -> Self {
             Self {
                 comment: Ok(value.comment),
                 integration: Ok(value.integration),
@@ -4278,12 +3827,9 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .ad_hoc = value
+            self.ad_hoc = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for ad_hoc: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for ad_hoc: {e}"));
             self
         }
         pub fn before_release<T>(mut self, value: T) -> Self
@@ -4291,12 +3837,9 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .before_release = value
+            self.before_release = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for before_release: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for before_release: {e}"));
             self
         }
         pub fn ci<T>(mut self, value: T) -> Self
@@ -4304,16 +3847,15 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .ci = value
+            self.ci = value
                 .try_into()
                 .map_err(|e| format!("error converting supplied value for ci: {e}"));
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration,
-    > for super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
+    impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration>
+        for super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration,
@@ -4326,7 +3868,8 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration>
-    for SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration {
+        for SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration
+    {
         fn from(
             value: super::SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration,
         ) -> Self {
@@ -4343,32 +3886,24 @@ pub mod builder {
         bug_bounty_available: Result<Option<bool>, String>,
         bug_bounty_url: Result<Option<String>, String>,
         comment: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment>,
             String,
         >,
         email_contact: Result<Option<String>, String>,
         in_scope: Result<
             Option<
-                Vec<
-                    super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem,
-                >,
+                Vec<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingInScopeItem>,
             >,
             String,
         >,
         out_scope: Result<
             Option<
-                Vec<
-                    super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem,
-                >,
+                Vec<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingOutScopeItem>,
             >,
             String,
         >,
         pgp_key: Result<
-            Option<
-                super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey,
-            >,
+            Option<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey>,
             String,
         >,
         security_policy: Result<Option<String>, String>,
@@ -4396,14 +3931,9 @@ pub mod builder {
             T: std::convert::TryInto<bool>,
             T::Error: std::fmt::Display,
         {
-            self
-                .accepts_vulnerability_reports = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for accepts_vulnerability_reports: {e}"
-                    )
-                });
+            self.accepts_vulnerability_reports = value.try_into().map_err(|e| {
+                format!("error converting supplied value for accepts_vulnerability_reports: {e}")
+            });
             self
         }
         pub fn bug_bounty_available<T>(mut self, value: T) -> Self
@@ -4411,14 +3941,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<bool>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .bug_bounty_available = value
-                .try_into()
-                .map_err(|e| {
-                    format!(
-                        "error converting supplied value for bug_bounty_available: {e}"
-                    )
-                });
+            self.bug_bounty_available = value.try_into().map_err(|e| {
+                format!("error converting supplied value for bug_bounty_available: {e}")
+            });
             self
         }
         pub fn bug_bounty_url<T>(mut self, value: T) -> Self
@@ -4426,29 +3951,21 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .bug_bounty_url = value
+            self.bug_bounty_url = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for bug_bounty_url: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for bug_bounty_url: {e}"));
             self
         }
         pub fn comment<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .comment = value
+            self.comment = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for comment: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for comment: {e}"));
             self
         }
         pub fn email_contact<T>(mut self, value: T) -> Self
@@ -4456,12 +3973,9 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .email_contact = value
+            self.email_contact = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for email_contact: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for email_contact: {e}"));
             self
         }
         pub fn in_scope<T>(mut self, value: T) -> Self
@@ -4475,12 +3989,9 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .in_scope = value
+            self.in_scope = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for in_scope: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for in_scope: {e}"));
             self
         }
         pub fn out_scope<T>(mut self, value: T) -> Self
@@ -4494,29 +4005,21 @@ pub mod builder {
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .out_scope = value
+            self.out_scope = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for out_scope: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for out_scope: {e}"));
             self
         }
         pub fn pgp_key<T>(mut self, value: T) -> Self
         where
             T: std::convert::TryInto<
-                Option<
-                    super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey,
-                >,
+                Option<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey>,
             >,
             T::Error: std::fmt::Display,
         {
-            self
-                .pgp_key = value
+            self.pgp_key = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for pgp_key: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for pgp_key: {e}"));
             self
         }
         pub fn security_policy<T>(mut self, value: T) -> Self
@@ -4524,18 +4027,15 @@ pub mod builder {
             T: std::convert::TryInto<Option<String>>,
             T::Error: std::fmt::Display,
         {
-            self
-                .security_policy = value
+            self.security_policy = value
                 .try_into()
-                .map_err(|e| {
-                    format!("error converting supplied value for security_policy: {e}")
-                });
+                .map_err(|e| format!("error converting supplied value for security_policy: {e}"));
             self
         }
     }
-    impl std::convert::TryFrom<
-        SecurityInsightsVersion100YamlSchemaVulnerabilityReporting,
-    > for super::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
+    impl std::convert::TryFrom<SecurityInsightsVersion100YamlSchemaVulnerabilityReporting>
+        for super::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting
+    {
         type Error = String;
         fn try_from(
             value: SecurityInsightsVersion100YamlSchemaVulnerabilityReporting,
@@ -4554,10 +4054,9 @@ pub mod builder {
         }
     }
     impl From<super::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting>
-    for SecurityInsightsVersion100YamlSchemaVulnerabilityReporting {
-        fn from(
-            value: super::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting,
-        ) -> Self {
+        for SecurityInsightsVersion100YamlSchemaVulnerabilityReporting
+    {
+        fn from(value: super::SecurityInsightsVersion100YamlSchemaVulnerabilityReporting) -> Self {
             Self {
                 accepts_vulnerability_reports: Ok(value.accepts_vulnerability_reports),
                 bug_bounty_available: Ok(value.bug_bounty_available),

--- a/skootrs-model/src/skootrs/mod.rs
+++ b/skootrs-model/src/skootrs/mod.rs
@@ -15,72 +15,240 @@
 
 pub mod facet;
 
-use std::error::Error;
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+    fmt,
+    str::FromStr,
+};
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+use strum::{EnumString, VariantNames};
+use url::Host;
 use utoipa::ToSchema;
 
-use self::facet::InitializedFacet;
+use self::facet::{InitializedFacet, SupportedFacetType};
 
+/// A helper type for the error type used throughout Skootrs. This is a `Box<dyn Error + Send + Sync>`.
 pub type SkootError = Box<dyn Error + Send + Sync>;
 
 /// The general structure of the models here is the struct names take the form:
 /// `<Thing>Params` reflecting the parameters for something to be created or initilized, like the parameters
 /// to create a repo or project.
-/// 
+///
 /// `Initialized<Thing>` models the data and state for a created or initialized thing, like a repo created inside of Github.
 /// This module is purely focused on the data for skootrs, and not for performing any of the operations. In order to make
 /// it easy for (de)serialization, the structs and impls only contain the logic for the data, and not for the operations,
 /// which falls under service.
 // TODO: These categories of structs should be moved to their own modules.
 /// Consts for the supported ecosystems, repos, etc. for convenient use by things like the CLI.
-pub const SUPPORTED_ECOSYSTEMS: [&str; 2] = [
-    "Go",
-    "Maven"
-];
+pub const SUPPORTED_ECOSYSTEMS: [&str; 2] = ["Go", "Maven"];
+
+/// The set of supported ecosystems.
+#[derive(Serialize, Deserialize, Clone, Debug, EnumString, VariantNames, Default)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub enum SupportedEcosystems {
+    /// The Go ecosystem
+    #[default]
+    Go,
+    /// The Maven ecosystem
+    Maven,
+}
 
 // TODO: These should be their own structs, but they're currently not any different from the params structs.
 
-/// Represents a project that has been initialized. This is the data and state of a project that has been 
+/// Represents a project that has been initialized. This is the data and state of a project that has been
 /// created.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct InitializedProject {
+    /// The metadata associated with an Skootrs initilialized source repository.
     pub repo: InitializedRepo,
+    /// The metadata associated with an Skootrs initilialized ecosystem.
     pub ecosystem: InitializedEcosystem,
+    /// The metadata associated with an Skootrs initilialized source location.
     pub source: InitializedSource,
-    pub facets: Vec<InitializedFacet>,
+    /// The facets associated with the project.
+    pub facets: HashMap<FacetMapKey, InitializedFacet>,
 }
 
-/// Represents the parameters for creating a project.
+impl InitializedProject {
+    /// Returns the set of keys for the facet `HashMap`
+    #[must_use]
+    pub fn facet_key_set(&self) -> HashSet<FacetMapKey> {
+        self.facets.keys().cloned().collect()
+    }
+}
+
+/// A helper enum for how a facet can be pulled from a `HashMap`
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(try_from = "String", into = "String")]
+pub enum FacetMapKey {
+    /// A map key based on the name of a facet. Useful for filtering based on the name of a facet.
+    Name(String),
+    /// A map key based on the type of a facet. Useful for filtering based on the type of facet.
+    Type(SupportedFacetType),
+}
+
+impl TryFrom<String> for FacetMapKey {
+    type Error = SkootError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let parts: Vec<&str> = value.split(": ").collect();
+        if parts.len() != 2 {
+            return Err("Invalid facet map key".into());
+        }
+        match parts.first() {
+            Some(&"Name") => Ok(Self::Name(parts[1].to_string())),
+            Some(&"Type") => Ok(Self::Type(parts[1].parse()?)),
+            _ => Err("Invalid facet map key".into()),
+        }
+    }
+}
+
+impl From<FacetMapKey> for String {
+    fn from(val: FacetMapKey) -> Self {
+        match val {
+            FacetMapKey::Name(x) => format!("Name: {x}"),
+            FacetMapKey::Type(x) => format!("Type: {x}"),
+        }
+    }
+}
+
+impl FromStr for FacetMapKey {
+    type Err = SkootError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(": ").collect();
+        if parts.len() != 2 {
+            return Err("Invalid facet map key".into());
+        }
+        match parts.first() {
+            Some(&"Name") => Ok(Self::Name(parts[1].to_string())),
+            Some(&"Type") => Ok(Self::Type(parts[1].parse()?)),
+            _ => Err("Invalid facet map key".into()),
+        }
+    }
+}
+
+// TODO: This seems redundant with From<FacetMapKey> for String.
+// I am not sure why this can't be automatically derived
+impl fmt::Display for FacetMapKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        String::from(self.clone()).fmt(f)?;
+        Ok(())
+    }
+}
+
+/// The parameters for creating a project.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub struct ProjectParams {
+pub struct ProjectCreateParams {
+    /// The name of the project to be created.
     pub name: String,
-    pub repo_params: RepoParams,
-    pub ecosystem_params: EcosystemParams,
-    pub source_params: SourceParams,
+    /// The parameters for creating the repository for the project.
+    pub repo_params: RepoCreateParams,
+    /// The parameters for initializing the ecosystem for the project.
+    pub ecosystem_params: EcosystemInitializeParams,
+    /// The parameters for initializing the source code for the project.
+    pub source_params: SourceInitializeParams,
+}
+
+/// The parameters for getting an existing Skootrs project.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ProjectGetParams {
+    /// The URL of the Skootrs project to get.
+    pub project_url: String,
+}
+
+/// The paramaters for getting the output of a project, e.g. an SBOM from a release
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ProjectOutputParams {
+    /// The URL of the Skootrs project to get the output from.
+    pub project_url: String,
+    /// The type of output to get from the project.
+    pub project_output_type: ProjectOutputType,
+    // TODO: Should project_output be a part of the ProjectOutputType enum?
+    /// The output to get from the project.
+    pub project_output: String,
+}
+
+/// The set of supported output types
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub enum ProjectOutputType {
+    /// An output type for getting an SBOM from a project.
+    SBOM,
+    /// An output type for getting a custom output from a project.
+    Custom(String),
+}
+
+/// The parameters for getting a facet from a project.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct FacetGetParams {
+    /// The URL of the Skootrs project to get the facet from.
+    pub project_url: String,
+    /// The key of the facet to get from the project.
+    pub facet_map_key: FacetMapKey,
 }
 
 /// Represents an initialized repository along with its host.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum InitializedRepo {
-    Github(InitializedGithubRepo)
+    /// An initialized Github repository.
+    Github(InitializedGithubRepo),
 }
 
 impl InitializedRepo {
     /// Returns the host URL of the repo.
-    #[must_use] pub fn host_url(&self) -> String {
+    #[must_use]
+    pub fn host_url(&self) -> String {
         match self {
             Self::Github(x) => x.host_url(),
         }
     }
 
     /// Returns the full URL to the repo.
-    #[must_use] pub fn full_url(&self) -> String {
+    #[must_use]
+    pub fn full_url(&self) -> String {
         match self {
             Self::Github(x) => x.full_url(),
+        }
+    }
+}
+
+impl TryFrom<String> for InitializedRepo {
+    type Error = SkootError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let parts = url::Url::parse(&value)?;
+        let path_segments = parts
+            .path_segments()
+            .map_or(Vec::new(), Iterator::collect::<Vec<_>>);
+        if path_segments.len() != 2 {
+            return Err(format!("Invalid repo URL: {value}").into());
+        }
+
+        let organization = *path_segments
+            .first()
+            .ok_or(format!("Invalid repo URL: {value}"))?;
+        let name = *path_segments
+            .get(1)
+            .ok_or(format!("Invalid repo URL: {value}"))?;
+        match parts.host() {
+            Some(Host::Domain("github.com")) => {
+                Ok(Self::Github(InitializedGithubRepo {
+                    name: name.to_string(),
+                    // FIXME: This will have issues if this isn't a user repo and in fact an organization user.
+                    organization: GithubUser::User(organization.into()),
+                }))
+            }
+            _ => Err("Unsupported repo host".into()),
         }
     }
 }
@@ -89,18 +257,22 @@ impl InitializedRepo {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct InitializedGithubRepo {
+    /// The name of the Github repository.
     pub name: String,
+    /// The organization the Github repository belongs to.
     pub organization: GithubUser,
 }
 
 impl InitializedGithubRepo {
     /// Returns the host URL of github.
-    #[must_use] pub fn host_url(&self) -> String {
+    #[must_use]
+    pub fn host_url(&self) -> String {
         "https://github.com".into()
     }
 
     /// Returns the full URL to the github repo.
-    #[must_use] pub fn full_url(&self) -> String {
+    #[must_use]
+    pub fn full_url(&self) -> String {
         format!(
             "{}/{}/{}",
             self.host_url(),
@@ -115,23 +287,35 @@ impl InitializedGithubRepo {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum InitializedEcosystem {
+    /// An initialized Go ecosystem for `InitializedSource`.
     Go(InitializedGo),
-    Maven(InitializedMaven)
+    /// An initialized Maven ecosystem `InitializedSource`.
+    Maven(InitializedMaven),
 }
 
-/// Represents the parameters for creating a repository.
+/// The parameters for creating a repository.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub enum RepoParams {
-    Github(GithubRepoParams)
+pub enum RepoCreateParams {
+    /// The parameters for creating a Github repository.
+    Github(GithubRepoParams),
 }
 
-/// Represents the parameters for initializing an ecosystem.
+/// The parameters for initializing an ecosystem.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub enum EcosystemParams {
+pub enum EcosystemInitializeParams {
+    /// The parameters for initializing a Go ecosystem for `InitializedSource`.
     Go(GoParams),
-    Maven(MavenParams)
+    /// The parameters for initializing a Maven ecosystem for `InitializedSource`.
+    Maven(MavenParams),
+}
+
+/// The parameter for getting an initialized repository
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct InitializedRepoGetParams {
+    /// The URL of the repository that Skootrs has previously initialized and you want to get.
+    pub repo_url: String,
 }
 
 /// Represents a Github user which is really just whether or not a repo belongs to  a user or organization.
@@ -140,16 +324,18 @@ pub enum EcosystemParams {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum GithubUser {
+    /// A Github user, i.e. not an organization.
     User(String),
+    /// A Github organization, i.e. not a user.
     Organization(String),
 }
 
 impl GithubUser {
     /// Returns the name of the user or organization.
-    #[must_use] pub fn get_name(&self) -> String {
+    #[must_use]
+    pub fn get_name(&self) -> String {
         match self {
-            Self::User(x) |
-            Self::Organization(x) => x.to_string(),
+            Self::User(x) | Self::Organization(x) => x.to_string(),
         }
     }
 }
@@ -158,17 +344,24 @@ impl GithubUser {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct GithubRepoParams {
+    /// The name of the Github repository.
     pub name: String,
+    /// The description of the Github repository.
     pub description: String,
+    /// The organization the Github repository belongs to.
     pub organization: GithubUser,
 }
 
 impl GithubRepoParams {
-    #[must_use] pub fn host_url(&self) -> String {
+    /// Helper for returning the github host.
+    #[must_use]
+    pub fn host_url(&self) -> String {
         "https://github.com".into()
     }
 
-    #[must_use] pub fn full_url(&self) -> String {
+    /// Helper for returning the full URL to the github repo.
+    #[must_use]
+    pub fn full_url(&self) -> String {
         format!(
             "{}/{}/{}",
             self.host_url(),
@@ -181,13 +374,15 @@ impl GithubRepoParams {
 /// Represents the parameters for initializing a source code repository.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub struct SourceParams {
+pub struct SourceInitializeParams {
+    /// The parent path of the source code repository.
     pub parent_path: String,
 }
 
-impl SourceParams {
+impl SourceInitializeParams {
     /// Returns the full path to the source code repository with the given name.
-    #[must_use] pub fn path(&self, name: &str) -> String {
+    #[must_use]
+    pub fn path(&self, name: &str) -> String {
         format!("{}/{}", self.parent_path, name)
     }
 }
@@ -195,7 +390,8 @@ impl SourceParams {
 /// Struct representing a working copy of source code.
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct InitializedSource {
-    pub path: String
+    /// The path to the source code repository.
+    pub path: String,
 }
 
 /// Represents the Maven ecosystem.
@@ -230,7 +426,8 @@ pub struct InitializedGo {
 
 impl InitializedGo {
     /// Returns the module name in the format "{host}/{name}".
-    #[must_use] pub fn module(&self) -> String {
+    #[must_use]
+    pub fn module(&self) -> String {
         format!("{}/{}", self.host, self.name)
     }
 }
@@ -247,7 +444,8 @@ pub struct InitializedMaven {
 
 impl GoParams {
     /// Returns the module name in the format "{host}/{name}".
-    #[must_use] pub fn module(&self) -> String {
+    #[must_use]
+    pub fn module(&self) -> String {
         format!("{}/{}", self.host, self.name)
     }
 }
@@ -255,14 +453,28 @@ impl GoParams {
 /// A set of configuration options for Skootrs.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub struct SkootrsConfig {
+pub struct Config {
+    /// The local path to cached projects. This is used by `LocalProjectService` for performing operations locally.
     pub local_project_path: String,
 }
 
-impl Default for SkootrsConfig {
+impl Default for Config {
     fn default() -> Self {
         Self {
-            local_project_path: "/tmp".into()
+            local_project_path: "/tmp".into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    #[test]
+    fn test_initialized_repo_try_from() {
+        let repo: InitializedRepo =
+            InitializedRepo::try_from("https://github.com/kusaridev/skootrs".to_string()).unwrap();
+        assert_eq!(repo.host_url(), "https://github.com");
+        assert_eq!(repo.full_url(), "https://github.com/kusaridev/skootrs");
     }
 }

--- a/skootrs-rest/src/server/project.rs
+++ b/skootrs-rest/src/server/project.rs
@@ -18,7 +18,7 @@ use serde::{Serialize, Deserialize};
 use skootrs_statestore::SurrealProjectStateStore;
 use utoipa::ToSchema;
 
-use skootrs_model::skootrs::ProjectParams;
+use skootrs_model::skootrs::ProjectCreateParams;
 use skootrs_lib::service::{ecosystem::LocalEcosystemService, facet::LocalFacetService, project::{LocalProjectService, ProjectService}, repo::LocalRepoService, source::LocalSourceService};
 
 /// An Error response for the REST API
@@ -69,7 +69,7 @@ pub(super) fn configure(store: Data<SurrealProjectStateStore>) -> impl FnOnce(&m
         (status = 409, description = "Project unable to be created", body = ErrorResponse, example = json!(ErrorResponse::InitializationError("Unable to create repo".into())))
     )
 )]
-pub(super) async fn create_project(params: Json<ProjectParams>, project_store: Data<SurrealProjectStateStore>) -> Result<impl Responder, actix_web::Error> {
+pub(super) async fn create_project(params: Json<ProjectCreateParams>, project_store: Data<SurrealProjectStateStore>) -> Result<impl Responder, actix_web::Error> {
     // TODO: This should be initialized elsewhere
     let project_service = LocalProjectService {
         repo_service: LocalRepoService {},

--- a/skootrs-rest/src/server/rest.rs
+++ b/skootrs-rest/src/server/rest.rs
@@ -24,8 +24,8 @@ use utoipa_redoc::{Redoc, Servable};
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::server::project::ErrorResponse;
-use skootrs_model::{skootrs::{InitializedProject, ProjectParams, InitializedRepo, InitializedGithubRepo, InitializedEcosystem, RepoParams, EcosystemParams, GithubUser, GithubRepoParams, SourceParams, InitializedSource, MavenParams, GoParams, InitializedGo, InitializedMaven, facet::{CommonFacetParams, SourceFileFacet, SourceFileFacetParams, InitializedFacet, FacetParams, SupportedFacetType}}, cd_events::repo_created::{RepositoryCreatedEvent, RepositoryCreatedEventContext, RepositoryCreatedEventContextId, RepositoryCreatedEventContextVersion, RepositoryCreatedEventSubject, RepositoryCreatedEventSubjectContent, RepositoryCreatedEventSubjectContentUrl, RepositoryCreatedEventSubjectId}, security_insights::insights10::{SecurityInsightsVersion100YamlSchema, SecurityInsightsVersion100YamlSchemaContributionPolicy, SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem, SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment, SecurityInsightsVersion100YamlSchemaDependencies, SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle, SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment, SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy, SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment, SecurityInsightsVersion100YamlSchemaDependenciesSbomItem, SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation, SecurityInsightsVersion100YamlSchemaHeader, SecurityInsightsVersion100YamlSchemaHeaderCommitHash, SecurityInsightsVersion100YamlSchemaProjectLifecycle, SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess, SecurityInsightsVersion100YamlSchemaSecurityArtifacts, SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment, SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment, SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel, SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment, SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem, SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment, SecurityInsightsVersion100YamlSchemaSecurityContactsItem, SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue, SecurityInsightsVersion100YamlSchemaSecurityTestingItem, SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment, SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration, SecurityInsightsVersion100YamlSchemaVulnerabilityReporting, SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment, SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey}};
-use skootrs_model::skootrs::facet::{SourceBundleFacet, SourceBundleFacetParams, APIBundleFacet, APIBundleFacetParams, SourceFileContent, APIContent};
+use skootrs_model::{skootrs::{InitializedProject, ProjectCreateParams, InitializedRepo, InitializedGithubRepo, InitializedEcosystem, RepoCreateParams, EcosystemInitializeParams, GithubUser, GithubRepoParams, SourceInitializeParams, InitializedSource, MavenParams, GoParams, InitializedGo, InitializedMaven, facet::{CommonFacetCreateParams, SourceFileFacet, SourceFileFacetParams, InitializedFacet, FacetCreateParams, SupportedFacetType}}, cd_events::repo_created::{RepositoryCreatedEvent, RepositoryCreatedEventContext, RepositoryCreatedEventContextId, RepositoryCreatedEventContextVersion, RepositoryCreatedEventSubject, RepositoryCreatedEventSubjectContent, RepositoryCreatedEventSubjectContentUrl, RepositoryCreatedEventSubjectId}, security_insights::insights10::{SecurityInsightsVersion100YamlSchema, SecurityInsightsVersion100YamlSchemaContributionPolicy, SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItem, SecurityInsightsVersion100YamlSchemaContributionPolicyAutomatedToolsListItemComment, SecurityInsightsVersion100YamlSchemaDependencies, SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycle, SecurityInsightsVersion100YamlSchemaDependenciesDependenciesLifecycleComment, SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicy, SecurityInsightsVersion100YamlSchemaDependenciesEnvDependenciesPolicyComment, SecurityInsightsVersion100YamlSchemaDependenciesSbomItem, SecurityInsightsVersion100YamlSchemaDependenciesSbomItemSbomCreation, SecurityInsightsVersion100YamlSchemaHeader, SecurityInsightsVersion100YamlSchemaHeaderCommitHash, SecurityInsightsVersion100YamlSchemaProjectLifecycle, SecurityInsightsVersion100YamlSchemaProjectLifecycleReleaseProcess, SecurityInsightsVersion100YamlSchemaSecurityArtifacts, SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessment, SecurityInsightsVersion100YamlSchemaSecurityArtifactsSelfAssessmentComment, SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModel, SecurityInsightsVersion100YamlSchemaSecurityArtifactsThreatModelComment, SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItem, SecurityInsightsVersion100YamlSchemaSecurityAssessmentsItemComment, SecurityInsightsVersion100YamlSchemaSecurityContactsItem, SecurityInsightsVersion100YamlSchemaSecurityContactsItemValue, SecurityInsightsVersion100YamlSchemaSecurityTestingItem, SecurityInsightsVersion100YamlSchemaSecurityTestingItemComment, SecurityInsightsVersion100YamlSchemaSecurityTestingItemIntegration, SecurityInsightsVersion100YamlSchemaVulnerabilityReporting, SecurityInsightsVersion100YamlSchemaVulnerabilityReportingComment, SecurityInsightsVersion100YamlSchemaVulnerabilityReportingPgpKey}};
+use skootrs_model::skootrs::facet::{SourceBundleFacet, SourceBundleFacetCreateParams, APIBundleFacet, APIBundleFacetParams, SourceFileContent, APIContent};
 
 /// Run the Skootrs REST API server.
 #[actix_web::main]
@@ -43,30 +43,30 @@ pub async fn run_server() -> std::io::Result<()> {
 
                 // Skootrs Model schemas
                 InitializedProject,
-                ProjectParams,
+                ProjectCreateParams,
                 InitializedRepo,
                 InitializedGithubRepo,
                 InitializedEcosystem,
-                RepoParams,
-                EcosystemParams,
+                RepoCreateParams,
+                EcosystemInitializeParams,
                 GithubUser,
                 GithubRepoParams,
-                SourceParams,
+                SourceInitializeParams,
                 InitializedSource,
                 MavenParams,
                 GoParams,
                 InitializedGo,
                 InitializedMaven,
                 // Facet Schemas
-                CommonFacetParams,
+                CommonFacetCreateParams,
                 SourceFileFacet,
                 SourceFileFacetParams,
                 InitializedFacet,
-                FacetParams,
+                FacetCreateParams,
                 SupportedFacetType,
                 InitializedProject,
                 SourceBundleFacet,
-                SourceBundleFacetParams,
+                SourceBundleFacetCreateParams,
                 APIBundleFacet,
                 APIBundleFacetParams,
                 SourceFileContent,

--- a/skootrs-statestore/Cargo.toml
+++ b/skootrs-statestore/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 surrealdb = { version = "1.1.1", features = ["kv-rocksdb"] }
 skootrs-lib = { path = "../skootrs-lib" }
 skootrs-model = { path = "../skootrs-model" }
+serde_json = "1.0.114"

--- a/skootrs-statestore/src/lib.rs
+++ b/skootrs-statestore/src/lib.rs
@@ -16,14 +16,23 @@
 //! This is the crate where the statestore where the management of `Skootrs` project state is defined.
 //! The statestore currently supports an in memory `SurrealDB` instance that writes to a file.
 
-use surrealdb::{engine::local::{Db, RocksDb}, Surreal};
+use std::collections::HashSet;
 
-use skootrs_model::skootrs::{InitializedProject, SkootError};
+use skootrs_lib::service::{
+    repo::{LocalRepoService, RepoService},
+    source::{LocalSourceService, SourceService},
+};
+use surrealdb::{
+    engine::local::{Db, RocksDb},
+    Surreal,
+};
+
+use skootrs_model::skootrs::{InitializedProject, InitializedRepo, InitializedSource, SkootError};
 
 /// The `SurrealDB` state store for Skootrs projects.
 #[derive(Debug)]
 pub struct SurrealProjectStateStore {
-    pub db: Surreal<Db>
+    pub db: Surreal<Db>,
 }
 
 /// The functionality for the `SurrealDB` state store for Skootrs projects.
@@ -36,18 +45,20 @@ impl SurrealProjectStateStore {
     pub async fn new() -> Result<Self, SkootError> {
         let db = Surreal::new::<RocksDb>("state.db").await?;
         db.use_ns("kusaridev").use_db("skootrs").await?;
-        Ok(Self {
-            db
-        })
+        Ok(Self { db })
     }
 
-    /// Store a new project in the state store. 
+    /// Store a new project in the state store.
     ///
     /// # Errors
     ///
     /// Returns an error if the project can't be stored in the state store.
-    pub async fn create(&self, project: InitializedProject) -> Result<Option<InitializedProject>, SkootError> {
-        let created = self.db
+    pub async fn create(
+        &self,
+        project: InitializedProject,
+    ) -> Result<Option<InitializedProject>, SkootError> {
+        let created = self
+            .db
             .create(("project", project.repo.full_url()))
             .content(project)
             .await?;
@@ -60,9 +71,7 @@ impl SurrealProjectStateStore {
     ///
     /// Returns an error if the project can't be fetched from the state store.
     pub async fn select(&self, repo_url: String) -> Result<Option<InitializedProject>, SkootError> {
-        let record = self.db
-            .select(("project", repo_url))
-            .await?;
+        let record = self.db.select(("project", repo_url)).await?;
         Ok(record)
     }
 
@@ -72,9 +81,158 @@ impl SurrealProjectStateStore {
     ///
     /// Returns an error if all the projects can't be dumped from the state store.
     pub async fn select_all(&self) -> Result<Vec<InitializedProject>, SkootError> {
-        let records = self.db
-            .select("project")
-            .await?;
+        let records = self.db.select("project").await?;
         Ok(records)
+    }
+}
+
+pub trait ProjectStateStore {
+    fn create(
+        &self,
+        project: InitializedProject,
+    ) -> impl std::future::Future<Output = Result<(), SkootError>> + Send;
+    fn read(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Option<InitializedProject>, SkootError>> + Send;
+    fn update(
+        &self,
+        project: InitializedProject,
+    ) -> impl std::future::Future<Output = Result<(), SkootError>> + Send;
+}
+
+pub struct GitProjectStateStore<S: SourceService> {
+    // TODO: This should be a git repo type of some sort
+    pub source: InitializedSource,
+    pub source_service: S,
+}
+
+impl ProjectStateStore for GitProjectStateStore<LocalSourceService> {
+    async fn create(&self, project: InitializedProject) -> Result<(), SkootError> {
+        self.source_service.write_file(
+            self.source.clone(),
+            "./",
+            ".skootrs".to_string(),
+            serde_json::to_string(&project)?,
+        )?;
+        self.source_service.commit_and_push_changes(
+            self.source.clone(),
+            "Updated skootrs project state".to_string(),
+        )?;
+        Ok(())
+    }
+
+    async fn read(&self) -> Result<Option<InitializedProject>, SkootError> {
+        let project = self
+            .source_service
+            .read_file(&self.source, "./", ".skootrs".to_string())?;
+        Ok(Some(serde_json::from_str(&project).unwrap()))
+    }
+
+    fn update(
+        &self,
+        project: InitializedProject,
+    ) -> impl std::future::Future<Output = Result<(), SkootError>> + Send {
+        self.create(project)
+    }
+}
+
+pub trait ProjectReferenceCache {
+    fn list(&self)
+        -> impl std::future::Future<Output = Result<HashSet<String>, SkootError>> + Send;
+    fn get(
+        &mut self,
+        repo_url: String,
+    ) -> impl std::future::Future<Output = Result<InitializedProject, SkootError>> + Send;
+    fn set(
+        &mut self,
+        repo_url: String,
+    ) -> impl std::future::Future<Output = Result<(), SkootError>> + Send;
+}
+
+pub struct InMemoryProjectReferenceCache {
+    pub save_path: String,
+    pub cache: HashSet<String>,
+    pub local_source_service: LocalSourceService,
+    pub local_repo_service: LocalRepoService,
+    pub clone_path: String,
+}
+
+impl ProjectReferenceCache for InMemoryProjectReferenceCache {
+    async fn list(&self) -> Result<HashSet<String>, SkootError> {
+        Ok(self.cache.clone())
+    }
+
+    async fn get(&mut self, repo_url: String) -> Result<InitializedProject, SkootError> {
+        let repo = InitializedRepo::try_from(repo_url)?;
+        /*let local_clone = self
+            .local_repo_service
+            .clone_local(repo, self.clone_path.clone())?;
+        let project =
+            self.local_source_service
+                .read_file(&local_clone, "./", ".skootrs".to_string())?;*/
+        let project = self
+            .local_repo_service
+            .fetch_file_content(&repo, ".skootrs")
+            .await?;
+        let initialized_project: InitializedProject = serde_json::from_str(&project)?;
+        Ok(initialized_project)
+    }
+
+    async fn set(&mut self, repo_url: String) -> Result<(), SkootError> {
+        self.cache.insert(repo_url);
+        self.save()?;
+        Ok(())
+    }
+}
+
+impl InMemoryProjectReferenceCache {
+    /// Create a new `InMemoryProjectReferenceCache` instance. The `save_path` is the path to the file where the cache will be saved.
+    #[must_use]
+    pub fn new(save_path: String) -> Self {
+        Self {
+            save_path,
+            cache: HashSet::new(),
+            local_source_service: LocalSourceService {},
+            local_repo_service: LocalRepoService {},
+            clone_path: "/tmp".to_string(),
+        }
+    }
+
+    /// Load the cache from the file at `save_path` or create a new cache if the file does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cache can't be loaded or created.
+    pub fn load_or_create(path: &str) -> Result<Self, SkootError> {
+        let mut cache = Self::new(path.to_string());
+        Ok(if cache.load().is_ok() {
+            cache
+        } else {
+            cache.save()?;
+            cache
+        })
+    }
+
+    /// Load the cache from the file at `save_path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cache can't be loaded.
+    pub fn load(&mut self) -> Result<(), SkootError> {
+        let deserialized_cache: HashSet<String> =
+            serde_json::from_str(&std::fs::read_to_string(&self.save_path)?)?;
+        self.cache = deserialized_cache;
+        Ok(())
+    }
+
+    /// Save the cache to the file at `save_path` in the struct.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the cache can't be saved.
+    pub fn save(&self) -> Result<(), SkootError> {
+        let serialized_cache = serde_json::to_string(&self.cache)?;
+        std::fs::write(&self.save_path, serialized_cache)?;
+        Ok(())
     }
 }


### PR DESCRIPTION
This has updated a ton of stuff including the CLI to be even more noun-verb while being easily extensible, as well as refactor how a ton of the state is store and managed in order to make it easy to fetch content and follow references from the elements in the state.

A lot more cleanup has to be done